### PR TITLE
[ADD] Integration && Mybatis mapper 테스트를 위한 H2 Database 설정 및 UserMapper 테스트 코드 작성

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,13 +1,22 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.jetbrains:annotations:23.0.0'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.mindrot:jbcrypt:0.4'
-    implementation project(':common')
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
     implementation 'com.google.code.gson:gson:2.8.6'
+
+    // Mybatis && MySQL
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
     runtimeOnly 'mysql:mysql-connector-java:8.0.28'
+
+    // Common
+    implementation project(':common')
+
+    //test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
+    testImplementation 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 test{

--- a/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
+++ b/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
@@ -1,4 +1,4 @@
-package com.jongho.dao;
+package com.jongho.common.dao;
 
 import org.mybatis.spring.annotation.MapperScan;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;

--- a/api/src/test/java/com/jongho/common/dao/RepositoryTestConfiguration.java
+++ b/api/src/test/java/com/jongho/common/dao/RepositoryTestConfiguration.java
@@ -1,4 +1,4 @@
-package com.jongho.dao;
+package com.jongho.common.dao;
 
 import com.jongho.common.config.MyBatisConfig;
 import com.jongho.config.DataSourceConfig;

--- a/api/src/test/java/com/jongho/common/integration/BaseIntegrationTest.java
+++ b/api/src/test/java/com/jongho/common/integration/BaseIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.jongho.common.integration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = "spring.profiles.active=test")
+@AutoConfigureMockMvc
+public class BaseIntegrationTest {
+    @Autowired
+    protected MockMvc mockMvc;
+}

--- a/api/src/test/java/com/jongho/dao/BaseMapperTest.java
+++ b/api/src/test/java/com/jongho/dao/BaseMapperTest.java
@@ -1,0 +1,52 @@
+package com.jongho.dao;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@ActiveProfiles("test")
+@MybatisTest(properties = "spring.profiles.active=test")
+@MapperScan(basePackages = "com.jongho.**.dao.mapper")
+@ContextConfiguration(classes = RepositoryTestConfiguration.class)
+public class BaseMapperTest {
+    @Autowired
+    private DataSource dataSource;
+
+    private void excuteTruncateTable(String tableName){
+        String sql = "TRUNCATE TABLE " + tableName;
+        try(Connection connection = dataSource.getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(sql)){
+            preparedStatement.execute();
+        }
+        catch (SQLException e){
+            e.printStackTrace();
+        }
+    }
+
+    private void initializeAutoIncrement(String tableName){
+        String sql = "ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1;";
+        try(Connection connection = dataSource.getConnection();
+            PreparedStatement preparedStatement = connection.prepareStatement(sql)){
+            preparedStatement.execute();
+        }
+        catch (SQLException e){
+            e.printStackTrace();
+        }
+    }
+
+    protected void cleanUpUserTable(){
+        excuteTruncateTable("users");
+        initializeAutoIncrement("users");
+    }
+    protected void cleanUpUserNotificationSettingTable(){
+        excuteTruncateTable("user_notification_settings");
+        initializeAutoIncrement("user_notification_settings");
+    }
+}

--- a/api/src/test/java/com/jongho/dao/RepositoryTestConfiguration.java
+++ b/api/src/test/java/com/jongho/dao/RepositoryTestConfiguration.java
@@ -1,0 +1,11 @@
+package com.jongho.dao;
+
+import com.jongho.common.config.MyBatisConfig;
+import com.jongho.config.DataSourceConfig;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@Import({MyBatisConfig.class, DataSourceConfig.class})
+@TestConfiguration
+public class RepositoryTestConfiguration {
+}

--- a/api/src/test/java/com/jongho/user/dao/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/jongho/user/dao/mapper/UserMapperTest.java
@@ -1,0 +1,52 @@
+package com.jongho.user.dao.mapper;
+
+import com.jongho.common.dao.BaseMapperTest;
+import com.jongho.user.domain.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("UserMapper 인터페이스")
+public class UserMapperTest extends BaseMapperTest {
+    @Autowired
+    private UserMapper userMapper;
+
+    @Nested
+    @DisplayName("createUser 메소드는")
+    class Describe_createUser {
+        @AfterEach
+        void setUp() {
+            cleanUpUserTable();
+        }
+        @Test
+        @DisplayName("인자로 받은 유저를 저장한다.")
+        void 유저를_생성한다() {
+            // given
+            User user = new User("jonghao", "a123b123", "whdgh9595", "01012341234", null);
+
+            // when
+            int userId = userMapper.createUser(user);
+
+            // then
+            assertEquals(1, userId);
+        }
+
+        @Test
+        @DisplayName("인자로 받은 username으로 유저를 조회한다.")
+        void 유저를_조회한다() {
+            // given
+            User user = new User("jonghao", "a123b123", "whdgh9595", "01012341234", null);
+
+            // when
+            userMapper.createUser(user);
+            User selectUser = userMapper.findOneByUsername(user.getUsername());
+
+            // then
+            assertEquals(user.getUsername(), selectUser.getUsername());
+        }
+    }
+}

--- a/common/src/main/resources/schema.sql
+++ b/common/src/main/resources/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS user_notification_settings (
   friendship int NOT NULL DEFAULT 1 COMMENT '친구신청 알림 설정 여부',
   is_deleted int NOT NULL DEFAULT 0 COMMENT '삭제 여부',
   deleted_time timestamp COMMENT '삭제 날짜',
-  chatroom_membership_request int NOT NULL DEFAULT 1 COMMENT '채팅방 입장 신청 알림 설정 여부'
+  chat_room_membership_request int NOT NULL DEFAULT 1 COMMENT '채팅방 입장 신청 알림 설정 여부'
 );
 
 CREATE TABLE IF NOT EXISTS hobby_categories (


### PR DESCRIPTION
## 기능 정의
H2 인메모리 데이터베이스 설정
BaseIntegrationTest 작성
BaseMapperTest 작성

## 주요 변경 및 추가 사항
1. 통합 테스트용 H2 인메모리 데이터베이스를 설정하고 TestConfigure 어노테이션을 사용하여 미리 만들어둔 java config 클래스를
import 하여 사용했습니다.
2. 재사용을 위한 BaseIntegrationTest, BaseMapperTes을 작성하고 중복되는 코드를 줄이고 테스트에 용이하게 작성하였습니다.
3. ActiveProfile 어노테이션을 이용해서 test 환경으로 동작하게 만들었습니다.
4. Mybatis와 Integration 테스트시 어플리케이션 컨텍스트를 불러올때 properties가 오버라이딩 되서 local로 바뀌는걸 방지하고자
MybatisTest, SpringBootTest 어노테이션에 properties인자를 spring.profiles.active를 test로 명시해줬습니다.
5. data.sql이 빈 파일로 존재했는데 H2데이터베이스 연동시 자동으로 참조되어서 삭제하였습니다.
6. Mybatis Mapper 테스트시 tear down용 메소드를 만들어서 데이터를 정리하였습니다.

## 테스트
UserMapper의 저장과 조회의 유닛테스트를 추가하였습니다.

## 블로커
H2데이터베이스 설정이 블로커였습니다. 멀티커넥션을 해야 하다보니 Java Config로 작성한걸 적용되게 하는것이 어려웠고
그렇다보니 어플리케이션 컨텍스트를 부르는 과정에서 환경을 분리해줘야 했습니다.
ActiveProfile어노테이션을 사용하여 test환경으로 바꿨지만 api 패키지의 application.properties에서 default active를 local로 설정해놨는데 컨텍스트 로딩과 동시에 activeProfile이 오버라이딩 되어서 local로 변하면서 삽질을 많이 하게 되었습니다.

## 미흡한점
아직은 컨텍스트에 대한 개념이 확 잡히지 않고 properties의 우선순위와 컨텍스트의 로딩 워크플로우를 잘 몰랐던것 같습니다.
