### PR TITLE
로그인 로직 변경

### DIFF
--- a/api/src/main/java/com/jongho/common/util/jwt/AccessPayload.java
+++ b/api/src/main/java/com/jongho/common/util/jwt/AccessPayload.java
@@ -9,6 +9,5 @@ import lombok.RequiredArgsConstructor;
 @EqualsAndHashCode
 public class AccessPayload {
     private final Long userId;
-    private final String username;
     private final TokenType tokenType = TokenType.ACCESS_TOKEN;
 }

--- a/api/src/main/java/com/jongho/common/util/jwt/JwtUtil.java
+++ b/api/src/main/java/com/jongho/common/util/jwt/JwtUtil.java
@@ -34,7 +34,6 @@ public class JwtUtil {
 
         Map<String, Object> claims = new HashMap<String, Object>();
         claims.put("userId", accessPayload.getUserId());
-        claims.put("username", accessPayload.getUsername());
         claims.put("tokenType", accessPayload.getTokenType().getValue());
 
         Date expireTime = new Date();
@@ -81,8 +80,7 @@ public class JwtUtil {
             }
 
             return new AccessPayload(
-                    claims.get("userId", Long.class),
-                    claims.get("username", String.class));
+                    claims.get("userId", Long.class));
         } catch (ExpiredJwtException e) {
             throw new ExpiredJwtException(null, null, "토큰이 만료되었습니다.");
         } catch (JwtException e) {

--- a/api/src/main/java/com/jongho/user/application/facade/AuthUserFacadeImpl.java
+++ b/api/src/main/java/com/jongho/user/application/facade/AuthUserFacadeImpl.java
@@ -30,7 +30,7 @@ public class AuthUserFacadeImpl implements AuthUserFacade {
         if(!BcryptUtil.checkPassword(password, user.getPassword())) {
             throw new UnAuthorizedException("비밀번호가 일치하지 않습니다.");
         }
-        AccessPayload accessPayload = new AccessPayload(user.getId(), user.getUsername());
+        AccessPayload accessPayload = new AccessPayload(user.getId());
         RefreshPayload refreshPayload = new RefreshPayload(user.getId());
 
         String refreshToken = jwtUtil.createRefreshToken(refreshPayload);

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE TABLE IF NOT EXISTS auth_users (
   id int PRIMARY KEY AUTO_INCREMENT,
-  user_id int NOT NULL COMMENT '자기자신의 id',
+  user_id int UNIQUE NOT NULL COMMENT '자기자신의 id',
   refresh_token varchar(255) NOT NULL COMMENT '리프레시 토큰',
   is_deleted int NOT NULL DEFAULT 0 COMMENT '삭제 여부',
   deleted_time timestamp COMMENT '삭제 날짜',

--- a/api/src/test/java/com/jongho/user/application/facade/AuthUserFacadeImplTest.java
+++ b/api/src/test/java/com/jongho/user/application/facade/AuthUserFacadeImplTest.java
@@ -65,7 +65,7 @@ public class AuthUserFacadeImplTest {
             userSignInDto = new UserSignInDto("jonghao1@", "whdgh9595");
             user = new User(1L, "whdgh9595", BcryptUtil.hashPassword("jonghao1@"), "whdgh9595", "01012341234", null);
             authUser = new AuthUser(user.getId(), refreshToken);
-            accessPayload = new AccessPayload(user.getId(), user.getUsername());
+            accessPayload = new AccessPayload(user.getId());
             refreshPayload = new RefreshPayload(user.getId());
             mockJwtUtilCreateAccessToken = when(jwtUtil.createAccessToken(accessPayload)).thenReturn(accessToekn);
             mockJwtUtilCreateRefreshToken = when(jwtUtil.createRefreshToken(refreshPayload)).thenReturn(refreshToken);


### PR DESCRIPTION
## 기능 정의
기존에 로그인시 생성했던 토큰의 payload 참조값을 userId -> authUserId로 변경

## 주요 변경 및 추가 사항
1. 유저의 직접적인 정보를 토큰의 payload에 담지 않고 authUser -> user를 참조하여 한단계 거칠수 있도록 authUserId로 참조할만한 키를 변경하였습니다.
2. sign-in시에 auth_users를 생성하던 로직을 sign-up시에 자동으로 생성하도록 변경하였습니다.
3. 스키마에 refresh_token을 null허용으로 변경하였습니다.

---
위의 사항들중에서 변경해야할 부분이 username만 삭제하면 되어서 커밋 롤백 후 username관련 로직만 삭제하여 푸시했습니다.


## 테스트
sign-in 에서 userId로 참조하던 로직을 authUserId로 참조하도록 테스트코드도 변경하였습니다.

## 블로커

## 미흡한점
