### PR TITLE
Feature/open chat rooms create

### DIFF
--- a/api/src/main/java/com/jongho/category/application/service/CategoryService.java
+++ b/api/src/main/java/com/jongho/category/application/service/CategoryService.java
@@ -3,8 +3,10 @@ package com.jongho.category.application.service;
 import com.jongho.category.domain.model.Category;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryService {
     public List<Category> getMainCategory();
     public List<Category> getSubCategory(Long parentId);
+    public Optional<Category> getOneCategoryById(Long categoryId);
 }

--- a/api/src/main/java/com/jongho/category/application/service/CategoryServiceImpl.java
+++ b/api/src/main/java/com/jongho/category/application/service/CategoryServiceImpl.java
@@ -29,4 +29,9 @@ public class CategoryServiceImpl implements CategoryService {
 
         return categoryRepository.selectSubCategory(parentId);
     }
+
+    @Override
+    public Optional<Category> getOneCategoryById(Long categoryId) {
+        return categoryRepository.selectOneCategoryById(categoryId);
+    }
 }

--- a/api/src/main/java/com/jongho/common/exception/MaxChatRoomsExceededException.java
+++ b/api/src/main/java/com/jongho/common/exception/MaxChatRoomsExceededException.java
@@ -1,0 +1,10 @@
+package com.jongho.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MaxChatRoomsExceededException extends CustomBusinessException{
+    public MaxChatRoomsExceededException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomCreateDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomCreateDto.java
@@ -17,10 +17,8 @@ public class OpenChatRoomCreateDto {
     @Nullable
     private final String notice;
     @NotNull
-    @NotEmpty
     private final Long categoryId;
     @NotNull
-    @NotEmpty
     private final int maximumCapacity;
     @Nullable
     private final String password;

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomCreateDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomCreateDto.java
@@ -1,0 +1,39 @@
+package com.jongho.openChatRoom.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class OpenChatRoomCreateDto {
+    @NotNull
+    @NotEmpty
+    private final String title;
+    @Nullable
+    private final String notice;
+    @NotNull
+    @NotEmpty
+    private final Long categoryId;
+    @NotNull
+    @NotEmpty
+    private final int maximumCapacity;
+    @Nullable
+    private final String password;
+    @JsonCreator
+    public OpenChatRoomCreateDto(@JsonProperty("title") String title,
+                                 @JsonProperty("notice") String notice,
+                                 @JsonProperty("category_id") Long categoryId,
+                                 @JsonProperty("maximum_capacity") int maximumCapacity,
+                                 @JsonProperty("password") String password) {
+        this.title = title;
+        this.notice = notice;
+        this.categoryId = categoryId;
+        this.maximumCapacity = maximumCapacity;
+        this.password = password;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
@@ -1,0 +1,7 @@
+package com.jongho.openChatRoom.application.facade;
+
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+
+public interface OpenChatRoomFacade {
+    public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto);
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -1,0 +1,35 @@
+package com.jongho.openChatRoom.application.facade;
+
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.service.OpenChatRoomService;
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
+    private final OpenChatRoomService openChatRoomService;
+    private final OpenChatRoomUserService openChatRoomUserService;
+    @Override
+    @Transactional
+    public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto) {
+        if(openChatRoomService.getCountByManagerId(authUserId) > 5){
+            throw new RuntimeException("최대 개설 가능한 채팅방 개수를 초과하였습니다.");
+        }
+        OpenChatRoom openChatRoom = new OpenChatRoom(
+                openChatRoomCreateDto.getTitle(),
+                openChatRoomCreateDto.getNotice(),
+                authUserId,
+                openChatRoomCreateDto.getCategoryId(),
+                openChatRoomCreateDto.getMaximumCapacity(),
+                openChatRoomCreateDto.getPassword()
+        );
+        openChatRoomService.createOpenChatRoom(openChatRoom);
+        openChatRoomUserService.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), authUserId));
+        openChatRoomService.updateIncrementCurrentCapacity(openChatRoom.getId());
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -17,7 +17,7 @@ public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
     @Override
     @Transactional
     public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto) {
-        if(openChatRoomService.getCountByManagerId(authUserId) > 5){
+        if(openChatRoomService.getCountByManagerId(authUserId) >= 5){
             throw new RuntimeException("최대 개설 가능한 채팅방 개수를 초과하였습니다.");
         }
         OpenChatRoom openChatRoom = new OpenChatRoom(
@@ -30,6 +30,5 @@ public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
         );
         openChatRoomService.createOpenChatRoom(openChatRoom);
         openChatRoomUserService.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), authUserId));
-        openChatRoomService.updateIncrementCurrentCapacity(openChatRoom.getId());
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -1,5 +1,8 @@
 package com.jongho.openChatRoom.application.facade;
 
+import com.jongho.category.application.service.CategoryService;
+import com.jongho.common.exception.CategoryNotFoundException;
+import com.jongho.common.exception.MaxChatRoomsExceededException;
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
 import com.jongho.openChatRoom.application.service.OpenChatRoomService;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
@@ -14,12 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
     private final OpenChatRoomService openChatRoomService;
     private final OpenChatRoomUserService openChatRoomUserService;
+    private final CategoryService categoryService;
     @Override
     @Transactional
     public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto) {
         if(openChatRoomService.getCountByManagerId(authUserId) >= 5){
-            throw new RuntimeException("최대 개설 가능한 채팅방 개수를 초과하였습니다.");
+            throw new MaxChatRoomsExceededException("최대 개설 가능한 채팅방 개수를 초과하였습니다.");
         }
+        categoryService.getOneCategoryById(openChatRoomCreateDto.getCategoryId()).orElseThrow(()->new CategoryNotFoundException("존재하지 않는 카테고리입니다."));
+
         OpenChatRoom openChatRoom = new OpenChatRoom(
                 openChatRoomCreateDto.getTitle(),
                 openChatRoomCreateDto.getNotice(),

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -1,11 +1,9 @@
-package com.jongho.openChatRoom.dao.mapper;
+package com.jongho.openChatRoom.application.service;
 
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import org.apache.ibatis.annotations.Mapper;
 
-@Mapper
-public interface OpenChatRoomMapper {
-    public int countByManagerId(Long managerId);
+public interface OpenChatRoomService {
     public void createOpenChatRoom(OpenChatRoom openChatRoom);
+    public int getCountByManagerId(Long managerId);
     public void updateIncrementCurrentCapacity(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -1,0 +1,24 @@
+package com.jongho.openChatRoom.application.service;
+
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatRoomServiceImpl implements OpenChatRoomService{
+    private final OpenChatRoomRepository openChatRoomRepository;
+    @Override
+    public void createOpenChatRoom(OpenChatRoom openChatRoom) {
+        openChatRoomRepository.createOpenChatRoom(openChatRoom);
+    }
+    @Override
+    public int getCountByManagerId(Long managerId) {
+        return openChatRoomRepository.countByManagerId(managerId);
+    }
+    @Override
+    public void updateIncrementCurrentCapacity(Long openChatRoomId) {
+        openChatRoomRepository.updateIncrementCurrentCapacity(openChatRoomId);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
+++ b/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
@@ -1,0 +1,29 @@
+package com.jongho.openChatRoom.controller;
+
+import com.jongho.common.annotaition.HttpRequestLogging;
+import com.jongho.common.response.BaseResponseEntity;
+import com.jongho.common.util.threadlocal.AuthenticatedUserThreadLocalManager;
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.facade.OpenChatRoomFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@HttpRequestLogging
+@RequestMapping("/api/v1/open-chat-rooms")
+public class OpenChatRoomController {
+    private final OpenChatRoomFacade openChatRoomFacade;
+
+    @PostMapping
+    public ResponseEntity<BaseResponseEntity<?>> createOpenChatRoom(@Validated @RequestBody OpenChatRoomCreateDto openChatRoomCreateDto){
+        openChatRoomFacade.createOpenChatRoomAndOpenChatRoomUser(AuthenticatedUserThreadLocalManager.get(), openChatRoomCreateDto);
+
+        return BaseResponseEntity.create("open chat room create");
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -1,0 +1,8 @@
+package com.jongho.openChatRoom.dao.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OpenChatRoomMapper {
+    public int countByManagerId();
+}

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.jongho.openChatRoom.dao.repository;
 
 import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,15 @@ import org.springframework.stereotype.Repository;
 public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository {
     private final OpenChatRoomMapper openChatRoomMapper;
     @Override
-    public int countByManagerId() {
-        return openChatRoomMapper.countByManagerId();
+    public int countByManagerId(Long managerId) {
+        return openChatRoomMapper.countByManagerId(managerId);
+    }
+    @Override
+    public void createOpenChatRoom(OpenChatRoom openChatRoom) {
+        openChatRoomMapper.createOpenChatRoom(openChatRoom);
+    }
+    @Override
+    public void updateIncrementCurrentCapacity(Long openChatRoomId) {
+        openChatRoomMapper.updateIncrementCurrentCapacity(openChatRoomId);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -1,0 +1,16 @@
+package com.jongho.openChatRoom.dao.repository;
+
+import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository {
+    private final OpenChatRoomMapper openChatRoomMapper;
+    @Override
+    public int countByManagerId() {
+        return openChatRoomMapper.countByManagerId();
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
@@ -1,11 +1,9 @@
 package com.jongho.openChatRoom.domain.model;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @RequiredArgsConstructor
 @EqualsAndHashCode

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
@@ -16,4 +16,14 @@ public class OpenChatRoom {
     private final int maximumCapacity;
     private final int currentAttendance;
     private final String password;
+
+    public OpenChatRoom(String title, String notice, Long managerId, Long categoryId, int maximumCapacity, String password) {
+        this.title = title;
+        this.notice = notice;
+        this.managerId = managerId;
+        this.categoryId = categoryId;
+        this.maximumCapacity = maximumCapacity;
+        this.currentAttendance = 0;
+        this.password = password;
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/OpenChatRoom.java
@@ -1,0 +1,21 @@
+package com.jongho.openChatRoom.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class OpenChatRoom {
+    private Long id;
+    private final String title;
+    private final String notice;
+    private final Long managerId;
+    private final Long categoryId;
+    private final int maximumCapacity;
+    private final int currentAttendance;
+    private final String password;
+}

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -1,0 +1,5 @@
+package com.jongho.openChatRoom.domain.repository;
+
+public interface OpenChatRoomRepository {
+    public int countByManagerId();
+}

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -1,5 +1,9 @@
 package com.jongho.openChatRoom.domain.repository;
 
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+
 public interface OpenChatRoomRepository {
-    public int countByManagerId();
+    public int countByManagerId(Long managerId);
+    public void createOpenChatRoom(OpenChatRoom openChatRoom);
+    public void updateIncrementCurrentCapacity(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserService.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserService.java
@@ -1,0 +1,7 @@
+package com.jongho.openChatRoomUser.application.service;
+
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+
+public interface OpenChatRoomUserService {
+    public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+}

--- a/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImpl.java
@@ -1,0 +1,16 @@
+package com.jongho.openChatRoomUser.application.service;
+
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import com.jongho.openChatRoomUser.domain.repository.OpenChatRoomUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatRoomUserServiceImpl implements OpenChatRoomUserService{
+    private final OpenChatRoomUserRepository openChatRoomUserRepository;
+    @Override
+    public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser) {
+        openChatRoomUserRepository.createOpenChatRoomUser(openChatRoomUser);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
@@ -1,0 +1,9 @@
+package com.jongho.openChatRoomUser.dao.mapper;
+
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OpenChatRoomUserMapper {
+    void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+}

--- a/api/src/main/java/com/jongho/openChatRoomUser/dao/repository/OpenChatRoomUserMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/dao/repository/OpenChatRoomUserMybatisRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.jongho.openChatRoomUser.dao.repository;
+
+import com.jongho.openChatRoomUser.dao.mapper.OpenChatRoomUserMapper;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import com.jongho.openChatRoomUser.domain.repository.OpenChatRoomUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class OpenChatRoomUserMybatisRepositoryImpl implements OpenChatRoomUserRepository {
+    private final OpenChatRoomUserMapper openChatRoomUserMapper;
+    @Override
+    public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser) {
+        openChatRoomUserMapper.createOpenChatRoomUser(openChatRoomUser);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
@@ -1,0 +1,14 @@
+package com.jongho.openChatRoomUser.domain.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class OpenChatRoomUser {
+    private Long id;
+    private final Long openChatRoomId;
+    private final Long userId;
+}

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/repository/OpenChatRoomUserRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/repository/OpenChatRoomUserRepository.java
@@ -1,0 +1,7 @@
+package com.jongho.openChatRoomUser.domain.repository;
+
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+
+public interface OpenChatRoomUserRepository {
+    public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+}

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -10,12 +10,12 @@
         LIMIT 1
     </select>
     <insert id="createOpenChatRoom" parameterType="com.jongho.openChatRoom.domain.model.OpenChatRoom" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO open_chat_rooms (manager_id, title, notice, category_id, maximumCapacity, password)
+        INSERT INTO open_chat_rooms (manager_id, title, notice, category_id, maximum_capacity, password)
         VALUES (#{managerId}, #{title}, #{notice}, #{categoryId}, #{maximumCapacity}, #{password})
     </insert>
     <update id="updateIncrementCurrentCapacity" parameterType="Long">
         UPDATE open_chat_rooms
-        SET current_capacity = current_capacity + 1
+        SET current_attendance = current_attendance + 1
         WHERE id = #{id}
         AND deleted_time is null
     </update>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -9,4 +9,8 @@
         AND open_chat_rooms.deleted_time is null
         LIMIT 1
     </select>
+    <insert id="createOpenChatRoom" parameterType="com.jongho.openChatRoom.domain.model.OpenChatRoom" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO open_chat_rooms (manager_id, title, notice, category_id, maximumCapacity, password)
+        VALUES (#{managerId}, #{title}, #{notice}, #{categoryId}, #{maximumCapacity}, #{password})
+    </insert>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "//mybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper">
+    <select id="countByManagerId" parameterType="Long" resultType="int">
+        SELECT
+            COUNT(*) AS count
+        FROM open_chat_rooms
+        WHERE open_chat_rooms.manager_id = #{managerId}
+        AND open_chat_rooms.deleted_time is null
+        LIMIT 1
+    </select>
+</mapper>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -13,4 +13,10 @@
         INSERT INTO open_chat_rooms (manager_id, title, notice, category_id, maximumCapacity, password)
         VALUES (#{managerId}, #{title}, #{notice}, #{categoryId}, #{maximumCapacity}, #{password})
     </insert>
+    <update id="updateIncrementCurrentCapacity" parameterType="Long">
+        UPDATE open_chat_rooms
+        SET current_capacity = current_capacity + 1
+        WHERE id = #{id}
+        AND deleted_time is null
+    </update>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomUserMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomUserMapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "//mybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
-<mapper namespace="com.jongho.openChatRoom.dao.mapper.r">
-    <insert id="createOpenChatRoomUser" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO open_chat_room_user (open_chat_room_id, user_id )
+<mapper namespace="com.jongho.openChatRoomUser.dao.mapper.OpenChatRoomUserMapper">
+    <insert id="createOpenChatRoomUser" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser">
+        INSERT INTO open_chat_room_users (open_chat_room_id, user_id )
         VALUES (#{openChatRoomId}, #{userId})
     </insert>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomUserMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomUserMapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "//mybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.jongho.openChatRoom.dao.mapper.r">
+    <insert id="createOpenChatRoomUser" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO open_chat_room_user (open_chat_room_id, user_id )
+        VALUES (#{openChatRoomId}, #{userId})
+    </insert>
+</mapper>

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS open_chat_rooms (
   category_id int NOT NULL COMMENT '카테고리 id',
   maximum_capacity int NOT NULL COMMENT '오픈채팅방 최대 참여 가능 인원',
   current_attendance int NOT NULL DEFAULT 1 COMMENT '오픈채팅방 현재 참여한 인원',
-  password varchar(255) COMMENT '오픈채팅방 비밀번호',
+  password varchar(255) NULL COMMENT '오픈채팅방 비밀번호',
   is_deleted int NOT NULL DEFAULT 0 COMMENT '삭제 여부',
   deleted_time timestamp COMMENT '삭제 날짜',
   created_time timestamp NOT NULL DEFAULT NOW() COMMENT '생성 날짜'

--- a/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
+++ b/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
@@ -72,6 +72,11 @@ public class BaseMapperTest {
         initializeAutoIncrement("auth_users");
     }
 
+    protected void cleanUpOpenChatRoomTable(){
+        excuteTruncateTable("open_chat_rooms");
+        initializeAutoIncrement("open_chat_rooms");
+    }
+
     protected void setUpCategoryTable(){
         try {
             String sql = new String(Files.readAllBytes(Paths.get("src/test/resources/setupDummyData/categoryDummyData.sql")));

--- a/api/src/test/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImplTest.java
@@ -1,0 +1,100 @@
+package com.jongho.openChatRoom.application.facade;
+
+import com.jongho.category.application.service.CategoryService;
+import com.jongho.category.domain.model.Category;
+import com.jongho.common.exception.CategoryNotFoundException;
+import com.jongho.common.exception.MaxChatRoomsExceededException;
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.service.OpenChatRoomService;
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRoomFacadeImpl 클래스")
+public class OpenChatRoomFacadeImplTest {
+    @Mock
+    private OpenChatRoomService openChatRoomService;
+    @Mock
+    private OpenChatRoomUserService openChatRoomUserService;
+    @Mock
+    private CategoryService categoryService;
+    @InjectMocks
+    private OpenChatRoomFacadeImpl openChatRoomFacadeImpl;
+
+    @Nested
+    @DisplayName("createOpenChatRoom 메소드는")
+    class Describe_createOpenChatRoom {
+        private Long userId;
+        private OpenChatRoomCreateDto openChatRoomCreateDto;
+        private OpenChatRoom openChatRoom;
+        @BeforeEach
+        void setUp() {
+            userId = 1L;
+            openChatRoomCreateDto = new OpenChatRoomCreateDto(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+        }
+
+        @Test
+        @DisplayName("생성하려는 유저가 소유하고있는 챗룸이 5개 이상이면 MaxChatRoomsExceededException예외를 던진다")
+        void 생성하려는_유저가_소유하고있는_챗룸이_5개_이상이면_MaxChatRoomsExceededException예외를_던진다() {
+            // given
+            when(openChatRoomService.getCountByManagerId(userId)).thenReturn(5);
+
+            // when then
+            assertThrows(MaxChatRoomsExceededException.class, () -> {openChatRoomFacadeImpl.createOpenChatRoomAndOpenChatRoomUser(userId, openChatRoomCreateDto);});
+        }
+
+        @Test
+        @DisplayName("생성하려는 챗룸의 카테고리가 존재하지 않으면 CategoryNotFoundException예외를 던진다")
+        void 생성하려는_챗룸의_카테고리가_존재하지_않으면_CategoryNotFoundException예외를_던진다() {
+            // given
+            when(openChatRoomService.getCountByManagerId(userId)).thenReturn(4);
+            when(categoryService.getOneCategoryById(openChatRoomCreateDto.getCategoryId())).thenReturn(Optional.empty());
+
+            // when then
+            assertThrows(CategoryNotFoundException.class, () -> {openChatRoomFacadeImpl.createOpenChatRoomAndOpenChatRoomUser(userId, openChatRoomCreateDto);});
+        }
+
+        @Test
+        @DisplayName("생성하려는 챗룸의 카테고리가 존재하고, 유저가 소유하고있는 챗룸이 5개 이하이면 챗룸을 생성하고, 챗룸유저를 생성한다")
+        void 생성하려는_챗룸의_카테고리가_존재하고_유저가_소유하고있는_챗룸이_5개_이하이면_챗룸을_생성하고_챗룸유저를_생성한다() {
+            // given
+            when(openChatRoomService.getCountByManagerId(userId)).thenReturn(4);
+            when(categoryService.getOneCategoryById(openChatRoomCreateDto.getCategoryId())).thenReturn(Optional.of(new Category("카테고리이름", 1L)));
+            doNothing().when(openChatRoomService).createOpenChatRoom(openChatRoom);
+
+            // when
+            openChatRoomFacadeImpl.createOpenChatRoomAndOpenChatRoomUser(userId, openChatRoomCreateDto);
+
+            // then
+            verify(openChatRoomService, times(1)).createOpenChatRoom(openChatRoom);
+            verify(openChatRoomUserService, times(1)).createOpenChatRoomUser(any());
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.jongho.openChatRoom.application.service;
+
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRoomServiceImpl 클래스")
+public class OpenChatRoomServiceImplTest {
+    @Mock
+    private OpenChatRoomRepository openChatRoomRepository;
+    @InjectMocks
+    private OpenChatRoomServiceImpl openChatRoomServiceImpl;
+
+    @Nested
+    @DisplayName("createOpenChatRoom 메소드는")
+    class Describe_createOpenChatRoom {
+        @Test
+        @DisplayName("OpenChatRoomServiceImpl의 createOpenChatRoom 메소드를 호출한다")
+        void OpenChatRoomServiceImpl의_createOpenChatRoom메소드를_한번_호출한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            doNothing().when(openChatRoomRepository).createOpenChatRoom(openChatRoom);
+
+            // when
+            openChatRoomServiceImpl.createOpenChatRoom(openChatRoom);
+
+            // then
+            verify(openChatRoomRepository, times(1)).createOpenChatRoom(openChatRoom);
+        }
+    }
+
+    @Nested
+    @DisplayName("countByManagerId 메소드는")
+    class Describe_countByManagerId {
+        @Test
+        @DisplayName("OpenChatRoomServiceImpl의 countByManagerId 메소드를 호출해서 받은 count를 반환한다")
+        void OpenChatRoomServiceImpl의_countByManagerId메소드를_한번_호출해서_받은_count를_반환한다() {
+            // given
+            Long managerId = 1L;
+            when(openChatRoomRepository.countByManagerId(managerId)).thenReturn(5);
+
+            // when
+            int result = openChatRoomServiceImpl.getCountByManagerId(managerId);
+
+            // then
+            verify(openChatRoomRepository, times(1)).countByManagerId(managerId);
+            assertEquals(5, result);
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
@@ -1,0 +1,74 @@
+package com.jongho.openChatRoom.dao.mapper;
+
+import com.jongho.common.dao.BaseMapperTest;
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+@DisplayName("OpenChatRoomMapper 인터페이스")
+public class OpenChatRoomMapperTest extends BaseMapperTest {
+    @Autowired
+    private OpenChatRoomMapper openChatRoomMapper;
+
+    @Nested
+    @DisplayName("createOpenChatRoom 메소드는")
+    class Describe_createOpenChatRoom {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방을 저장한다.")
+        void 오픈채팅방을_생성한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+
+            // when
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // then
+            assertEquals(1, openChatRoom.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("countByManagerId 메소드는")
+    class Describe_countByManagerId {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 매니저 아이디를 가진 오픈채팅방의 개수를 반환한다.")
+        void 오픈채팅방의_개수를_반환한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // when
+            int count = openChatRoomMapper.countByManagerId(openChatRoom.getManagerId());
+
+            // then
+            assertEquals(3, count);
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
@@ -1,0 +1,75 @@
+package com.jongho.openChatRoom.presentation;
+
+import com.google.gson.Gson;
+import com.jongho.common.config.WebMvcConfig;
+import com.jongho.common.interceptor.AuthInterceptor;
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.facade.OpenChatRoomFacade;
+import com.jongho.openChatRoom.controller.OpenChatRoomController;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        value = OpenChatRoomController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {AuthInterceptor.class, WebMvcConfig.class})
+)
+@DisplayName("OpenChatRoomController 클래스")
+public class OpenChatRoomControllerTest {
+    @MockBean
+    private OpenChatRoomFacade openChatRoomFacade;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("createOpenChatRoom 메소드는")
+    class Describe_createOpenChatRoom {
+        private OpenChatRoomCreateDto openChatRoomCreateDto;
+
+        @BeforeEach
+        public void setUp() {
+            openChatRoomCreateDto = new OpenChatRoomCreateDto(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    200,
+                    "비밀번호");
+        }
+        @Test
+        @DisplayName("호출이 되면 status 201과 open chat room create라는 메세지를 반환한다.")
+        void 호출이_되면_status_201과_open_chat_room_create라는_메세지를_반환한다() throws Exception{
+            // given
+            doNothing().when(openChatRoomFacade).createOpenChatRoomAndOpenChatRoomUser(1L, new OpenChatRoomCreateDto(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    200,
+                    "비밀번호"));
+            Gson gson = new Gson();
+            String openChatRoomCreateDtoJson = gson.toJson(openChatRoomCreateDto);
+
+            // when
+            mockMvc.perform(post("/api/v1/open-chat-rooms")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(openChatRoomCreateDtoJson))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.message").value("open chat room create"))
+                    .andDo(print());
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImplTest.java
@@ -1,0 +1,43 @@
+package com.jongho.openChatRoomUser.application.service;
+
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import com.jongho.openChatRoomUser.domain.repository.OpenChatRoomUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRoomUserServiceImpl 클래스")
+public class OpenChatRoomUserServiceImplTest {
+    @Mock
+    private OpenChatRoomUserRepository openChatRoomUserRepository;
+    @InjectMocks
+    private OpenChatRoomUserServiceImpl openChatRoomUserServiceImpl;
+
+    @Nested
+    @DisplayName("createOpenChatRoomUser 메소드는")
+    class Describe_createOpenChatRoomUser {
+        @Test
+        @DisplayName("OpenChatRoomUserServiceImpl의 createOpenChatRoomUser 메소드를 호출한다")
+        void OpenChatRoomUserServiceImpl의_createOpenChatRoomUser메소드를_한번_호출한다() {
+            // given
+            OpenChatRoomUser openChatRoomUser = new OpenChatRoomUser(
+                    1L,
+                    2L
+            );
+            doNothing().when(openChatRoomUserRepository).createOpenChatRoomUser(openChatRoomUser);
+
+            // when
+            openChatRoomUserServiceImpl.createOpenChatRoomUser(openChatRoomUser);
+
+            // then
+            verify(openChatRoomUserRepository, times(1)).createOpenChatRoomUser(openChatRoomUser);
+        }
+    }
+}


### PR DESCRIPTION
## 기능 정의
오픈채팅방을 생성하는 기능입니다.

## 주요 변경 및 추가 사항
오픈채팅방 생성시 5개 이상일경우 생성을 제한하는 로직을 추가하였습니다.
채팅방의 카테고리가 존재하지 않을시 생성을 제한하는 로직을 추가하였습니다.
채팅방 생성시 방을 만든 유저가 바로 채팅방에 들어가는 로직을 추가하였습니다.

## 테스트
채팅방을 생성할때 사용되는 controller, service, mapper들의 테스트코드를 작성하였습니다.

## 블로커

## 미흡한점
