### PR TITLE
오픈채팅방 입장 API

### DIFF
--- a/api/src/main/java/com/jongho/common/exception/InvalidPasswordException.java
+++ b/api/src/main/java/com/jongho/common/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.jongho.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordException extends CustomBusinessException{
+    public InvalidPasswordException(String message) {
+        super(message, HttpStatus.FORBIDDEN);
+
+    }
+}

--- a/api/src/main/java/com/jongho/common/exception/MaxChatRoomsJoinException.java
+++ b/api/src/main/java/com/jongho/common/exception/MaxChatRoomsJoinException.java
@@ -1,0 +1,10 @@
+package com.jongho.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MaxChatRoomsJoinException extends CustomBusinessException{
+    public MaxChatRoomsJoinException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+
+    }
+}

--- a/api/src/main/java/com/jongho/common/exception/OpenChatRoonNotFoundException.java
+++ b/api/src/main/java/com/jongho/common/exception/OpenChatRoonNotFoundException.java
@@ -1,0 +1,9 @@
+package com.jongho.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class OpenChatRoonNotFoundException extends CustomBusinessException{
+    public OpenChatRoonNotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomJoinDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/request/OpenChatRoomJoinDto.java
@@ -1,0 +1,17 @@
+package com.jongho.openChatRoom.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class OpenChatRoomJoinDto {
+    @Nullable
+    private final String password;
+
+    public OpenChatRoomJoinDto(@JsonProperty("password") String password) {
+        this.password = password;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
@@ -4,4 +4,5 @@ import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
 
 public interface OpenChatRoomFacade {
     public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto);
+    public void joinOpenChatRoom(Long authUserId, Long openChatRoomId, String password);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.rmi.AlreadyBoundException;
 import java.util.Optional;
 
 @Service

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -2,9 +2,7 @@ package com.jongho.openChatRoom.application.facade;
 
 import com.jongho.category.application.service.CategoryService;
 import com.jongho.category.domain.model.Category;
-import com.jongho.common.exception.AlreadyExistsException;
-import com.jongho.common.exception.CategoryNotFoundException;
-import com.jongho.common.exception.MaxChatRoomsExceededException;
+import com.jongho.common.exception.*;
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
 import com.jongho.openChatRoom.application.service.OpenChatRoomService;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
@@ -49,5 +47,25 @@ public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
         );
         openChatRoomService.createOpenChatRoom(openChatRoom);
         openChatRoomUserService.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), authUserId));
+    }
+    @Override
+    @Transactional
+    public void joinOpenChatRoom(Long authUserId, Long openChatRoomId, String password) {
+        OpenChatRoom openChatRoom = openChatRoomService.getOpenChatRoomById(openChatRoomId)
+                .orElseThrow(()-> new OpenChatRoonNotFoundException("존재하지 않는 채팅방입니다."));
+        if(openChatRoom.getPassword() != null){
+            if(!openChatRoom.getPassword().equals(password)){
+                throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
+            }
+        }
+        if(openChatRoom.getMaximumCapacity() <= openChatRoom.getCurrentAttendance()){
+            throw new MaxChatRoomsJoinException("채팅방의 최대 인원을 초과하여 입장할 수 없습니다.");
+        }
+        Optional<OpenChatRoomUser> openChatRoomUser = openChatRoomUserService.getOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomId, authUserId);
+        if(openChatRoomUser.isPresent()){
+            throw new AlreadyExistsException("이미 참여중인 채팅방입니다.");
+        }
+        openChatRoomUserService.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoomId, authUserId));
+        openChatRoomService.incrementOpenChatRoomCurrentAttendance(openChatRoomId, openChatRoom.getCurrentAttendance());
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -9,4 +9,5 @@ public interface OpenChatRoomService {
     public int getOpenChatRoomCountByManagerId(Long managerId);
     public Optional<OpenChatRoom> getOpenChatRoomByManagerIdAndTitle(Long managerId, String title);
     public void incrementOpenChatRoomCurrentAttendance(Long openChatRoomId, int currentAttendance);
+    public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -27,4 +27,8 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
     public Optional<OpenChatRoom> getOpenChatRoomByManagerIdAndTitle(Long managerId, String title) {
         return openChatRoomRepository.selectOneOpenChatRoomByManagerIdAndTitle(managerId, title);
     }
+    @Override
+    public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId) {
+        return openChatRoomRepository.selectOneOpenChatRoomById(openChatRoomId);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
+++ b/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
@@ -5,14 +5,12 @@ import com.jongho.common.response.BaseMessageEnum;
 import com.jongho.common.response.BaseResponseEntity;
 import com.jongho.common.util.threadlocal.AuthenticatedUserThreadLocalManager;
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.dto.request.OpenChatRoomJoinDto;
 import com.jongho.openChatRoom.application.facade.OpenChatRoomFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +24,12 @@ public class OpenChatRoomController {
         openChatRoomFacade.createOpenChatRoomAndOpenChatRoomUser(AuthenticatedUserThreadLocalManager.get(), openChatRoomCreateDto);
 
         return BaseResponseEntity.create(BaseMessageEnum.CREATED.getValue());
+    }
+
+    @PostMapping("/{openChatRoomId}/join")
+    public ResponseEntity<BaseResponseEntity<?>> joinOpenChatRoom(@PathVariable("openChatRoomId") Long openChatRoomId, @Validated @RequestBody OpenChatRoomJoinDto openChatRoomJoinDto){
+        openChatRoomFacade.joinOpenChatRoom(AuthenticatedUserThreadLocalManager.get(), openChatRoomId, openChatRoomJoinDto.getPassword());
+
+        return BaseResponseEntity.ok(BaseMessageEnum.SUCCESS.getValue());
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -28,4 +28,8 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
     public Optional<OpenChatRoom> selectOneOpenChatRoomByManagerIdAndTitle(Long managerId, String title) {
         return Optional.ofNullable(openChatRoomMapper.selectOneOpenChatRoomByManagerIdAndTitle(managerId, title));
     }
+    @Override
+    public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId) {
+        return Optional.ofNullable(openChatRoomMapper.selectOneOpenChatRoomById(openChatRoomId));
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -9,4 +9,5 @@ public interface OpenChatRoomRepository {
     public void createOpenChatRoom(OpenChatRoom openChatRoom);
     public void updateIncrementCurrentCapacity(Long openChatRoomId, int currentAttendance);
     public Optional<OpenChatRoom> selectOneOpenChatRoomByManagerIdAndTitle(Long managerId, String title);
+    public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserService.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserService.java
@@ -2,6 +2,9 @@ package com.jongho.openChatRoomUser.application.service;
 
 import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 
+import java.util.Optional;
+
 public interface OpenChatRoomUserService {
     public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+    public Optional<OpenChatRoomUser> getOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImpl.java
@@ -5,6 +5,8 @@ import com.jongho.openChatRoomUser.domain.repository.OpenChatRoomUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class OpenChatRoomUserServiceImpl implements OpenChatRoomUserService{
@@ -12,5 +14,9 @@ public class OpenChatRoomUserServiceImpl implements OpenChatRoomUserService{
     @Override
     public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser) {
         openChatRoomUserRepository.createOpenChatRoomUser(openChatRoomUser);
+    }
+    @Override
+    public Optional<OpenChatRoomUser> getOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId) {
+        return openChatRoomUserRepository.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomId, userId);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
@@ -6,4 +6,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface OpenChatRoomUserMapper {
     void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+    OpenChatRoomUser selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapper.java
@@ -2,9 +2,10 @@ package com.jongho.openChatRoomUser.dao.mapper;
 
 import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface OpenChatRoomUserMapper {
     void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
-    OpenChatRoomUser selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId);
+    OpenChatRoomUser selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(@Param("openChatRoomId") Long openChatRoomId, @Param("userId") Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/dao/repository/OpenChatRoomUserMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/dao/repository/OpenChatRoomUserMybatisRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.jongho.openChatRoomUser.domain.repository.OpenChatRoomUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Repository
 public class OpenChatRoomUserMybatisRepositoryImpl implements OpenChatRoomUserRepository {
@@ -13,5 +15,10 @@ public class OpenChatRoomUserMybatisRepositoryImpl implements OpenChatRoomUserRe
     @Override
     public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser) {
         openChatRoomUserMapper.createOpenChatRoomUser(openChatRoomUser);
+    }
+
+    @Override
+    public Optional<OpenChatRoomUser> selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId) {
+        return Optional.ofNullable(openChatRoomUserMapper.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomId, userId));
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
@@ -4,7 +4,6 @@ import lombok.*;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @RequiredArgsConstructor
 @EqualsAndHashCode
 public class OpenChatRoomUser {

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
@@ -8,7 +8,6 @@ import lombok.*;
 @RequiredArgsConstructor
 @EqualsAndHashCode
 public class OpenChatRoomUser {
-    private Long id;
     private final Long openChatRoomId;
     private final Long userId;
 }

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/repository/OpenChatRoomUserRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/repository/OpenChatRoomUserRepository.java
@@ -2,6 +2,9 @@ package com.jongho.openChatRoomUser.domain.repository;
 
 import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 
+import java.util.Optional;
+
 public interface OpenChatRoomUserRepository {
     public void createOpenChatRoomUser(OpenChatRoomUser openChatRoomUser);
+    public Optional<OpenChatRoomUser> selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(Long openChatRoomId, Long userId);
 }

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -22,9 +22,9 @@
     <select id="selectOneOpenChatRoomByManagerIdAndTitle" parameterType="com.jongho.openChatRoom.domain.model.OpenChatRoom" resultType="com.jongho.openChatRoom.domain.model.OpenChatRoom">
         SELECT
             id,
-            manager_id,
             title,
             notice,
+            manager_id,
             category_id,
             maximum_capacity,
             current_attendance,
@@ -38,9 +38,9 @@
     <select id="selectOneOpenChatRoomById" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.OpenChatRoom">
         SELECT
             id,
-            manager_id,
             title,
             notice,
+            manager_id,
             category_id,
             maximum_capacity,
             current_attendance,

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -19,6 +19,22 @@
         WHERE id = #{id}
         AND deleted_time is null
     </update>
+    <select id="selectOneOpenChatRoomByManagerIdAndTitle" parameterType="com.jongho.openChatRoom.domain.model.OpenChatRoom" resultType="com.jongho.openChatRoom.domain.model.OpenChatRoom">
+        SELECT
+            id,
+            manager_id,
+            title,
+            notice,
+            category_id,
+            maximum_capacity,
+            current_attendance,
+            password
+        FROM open_chat_rooms
+        WHERE manager_id = #{managerId}
+        AND title = #{title}
+        AND deleted_time is null
+        LIMIT 1
+    </select>
     <select id="selectOneOpenChatRoomById" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.OpenChatRoom">
         SELECT
             id,

--- a/api/src/main/resources/mapper/openChatRoomUserMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomUserMapper.xml
@@ -5,4 +5,11 @@
         INSERT INTO open_chat_room_users (open_chat_room_id, user_id )
         VALUES (#{openChatRoomId}, #{userId})
     </insert>
+    <select id="selectOpenChatRoomUserByOpenChatRoomIdAndUserId" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" resultType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser">
+        SELECT open_chat_room_id, user_id
+        FROM open_chat_room_users
+        WHERE open_chat_room_id = #{openChatRoomId}
+        AND user_id = #{userId}
+        And deleted_time IS NULL
+    </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomUserMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomUserMapper.xml
@@ -5,11 +5,12 @@
         INSERT INTO open_chat_room_users (open_chat_room_id, user_id )
         VALUES (#{openChatRoomId}, #{userId})
     </insert>
-    <select id="selectOpenChatRoomUserByOpenChatRoomIdAndUserId" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" resultType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser">
+    <select id="selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" resultType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser">
         SELECT open_chat_room_id, user_id
         FROM open_chat_room_users
         WHERE open_chat_room_id = #{openChatRoomId}
         AND user_id = #{userId}
         And deleted_time IS NULL
+        LIMIT 1
     </select>
 </mapper>

--- a/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
+++ b/api/src/test/java/com/jongho/common/dao/BaseMapperTest.java
@@ -77,6 +77,10 @@ public class BaseMapperTest {
         initializeAutoIncrement("open_chat_rooms");
     }
 
+    protected void cleanUpOpenChatRoomUserTable(){
+        excuteTruncateTable("open_chat_room_users");
+    }
+
     protected void setUpCategoryTable(){
         try {
             String sql = new String(Files.readAllBytes(Paths.get("src/test/resources/setupDummyData/categoryDummyData.sql")));

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
@@ -10,6 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -25,8 +27,8 @@ public class OpenChatRoomServiceImplTest {
     @DisplayName("createOpenChatRoom 메소드는")
     class Describe_createOpenChatRoom {
         @Test
-        @DisplayName("OpenChatRoomServiceImpl의 createOpenChatRoom 메소드를 호출한다")
-        void OpenChatRoomServiceImpl의_createOpenChatRoom메소드를_한번_호출한다() {
+        @DisplayName("OpenChatRoomRepository의 createOpenChatRoom 메소드를 호출한다")
+        void OpenChatRoomRepository의_createOpenChatRoom메소드를_한번_호출한다() {
             // given
             OpenChatRoom openChatRoom = new OpenChatRoom(
                     "타이틀",
@@ -50,8 +52,8 @@ public class OpenChatRoomServiceImplTest {
     @DisplayName("countByManagerId 메소드는")
     class Describe_countByManagerId {
         @Test
-        @DisplayName("OpenChatRoomServiceImpl의 countByManagerId 메소드를 호출해서 받은 count를 반환한다")
-        void OpenChatRoomServiceImpl의_countByManagerId메소드를_한번_호출해서_받은_count를_반환한다() {
+        @DisplayName("OpenChatRoomRepository의 countByManagerId 메소드를 호출해서 받은 count를 반환한다")
+        void OpenChatRoomRepository의_countByManagerId메소드를_한번_호출해서_받은_count를_반환한다() {
             // given
             Long managerId = 1L;
             when(openChatRoomRepository.countByManagerId(managerId)).thenReturn(5);
@@ -62,6 +64,80 @@ public class OpenChatRoomServiceImplTest {
             // then
             verify(openChatRoomRepository, times(1)).countByManagerId(managerId);
             assertEquals(5, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateIncrementCurrentCapacity 메소드는")
+    class Describe_updateIncrementCurrentCapacity {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 updateIncrementCurrentCapacity 메소드를 호출한다")
+        void OpenChatRoomRepository의_updateIncrementCurrentCapacity메소드를_한번_호출한다() {
+            // given
+            Long openChatRoomId = 1L;
+            int currentAttendance = 1;
+            doNothing().when(openChatRoomRepository).updateIncrementCurrentCapacity(openChatRoomId, currentAttendance);
+
+            // when
+            openChatRoomServiceImpl.incrementOpenChatRoomCurrentAttendance(openChatRoomId, currentAttendance);
+
+            // then
+            verify(openChatRoomRepository, times(1)).updateIncrementCurrentCapacity(openChatRoomId, currentAttendance);
+        }
+    }
+
+    @Nested
+    @DisplayName("selectOneOpenChatRoomByManagerIdAndTitle 메소드는")
+    class Describe_selectOneOpenChatRoomByManagerIdAndTitle {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectOneOpenChatRoomByManagerIdAndTitle 메소드를 호출해서 받은 openChatRoom을 반환한다")
+        void OpenChatRoomRepository의_selectOneOpenChatRoomByManagerIdAndTitle메소드를_한번_호출해서_받은_openChatRoom을_반환한다() {
+            // given
+            Long managerId = 1L;
+            String title = "타이틀";
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            when(openChatRoomRepository.selectOneOpenChatRoomByManagerIdAndTitle(managerId, title)).thenReturn(Optional.of(openChatRoom));
+
+            // when
+            OpenChatRoom result = openChatRoomServiceImpl.getOpenChatRoomByManagerIdAndTitle(managerId, title).get();
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectOneOpenChatRoomByManagerIdAndTitle(managerId, title);
+            assertEquals(openChatRoom, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("selectOneOpenChatRoomById 메소드는")
+    class Describe_selectOneOpenChatRoomById {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectOneOpenChatRoomById 메소드를 호출해서 받은 openChatRoom을 반환한다")
+        void OpenChatRoomRepository의_selectOneOpenChatRoomById메소드를_한번_호출해서_받은_openChatRoom을_반환한다() {
+            // given
+            Long openChatRoomId = 1L;
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            when(openChatRoomRepository.selectOneOpenChatRoomById(openChatRoomId)).thenReturn(Optional.of(openChatRoom));
+
+            // when
+            OpenChatRoom result = openChatRoomServiceImpl.getOpenChatRoomById(openChatRoomId).get();
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectOneOpenChatRoomById(openChatRoomId);
+            assertEquals(openChatRoom, result);
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
@@ -69,4 +69,94 @@ public class OpenChatRoomMapperTest extends BaseMapperTest {
             assertEquals(1, count);
         }
     }
+
+    @Nested
+    @DisplayName("updateIncrementCurrentCapacity 메소드는")
+    class Describe_updateIncrementCurrentCapacity {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방의 현재 참여 인원을 1 증가시킨다.")
+        void 오픈채팅방의_현재_참여_인원을_1_증가시킨다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // when
+            openChatRoomMapper.updateIncrementCurrentCapacity(openChatRoom.getId(), 1);
+
+            // then
+            assertEquals(2, openChatRoomMapper.selectOneOpenChatRoomById(openChatRoom.getId()).getCurrentAttendance());
+        }
+    }
+
+    @Nested
+    @DisplayName("selectOneOpenChatRoomByManagerIdAndTitle 메소드는")
+    class Describe_selectOneOpenChatRoomByManagerIdAndTitle {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 매니저 아이디와 타이틀을 가진 오픈채팅방을 반환한다.")
+        void 오픈채팅방을_반환한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // when
+            OpenChatRoom result = openChatRoomMapper.selectOneOpenChatRoomByManagerIdAndTitle(openChatRoom.getManagerId(), openChatRoom.getTitle());
+
+            // then
+            assertEquals(openChatRoom.getId(), result.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("selectOneOpenChatRoomById 메소드는")
+    class Describe_selectOneOpenChatRoomById {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방 아이디를 가진 오픈채팅방을 반환한다.")
+        void 오픈채팅방을_반환한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀",
+                    "공지사항",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // when
+            OpenChatRoom result = openChatRoomMapper.selectOneOpenChatRoomById(openChatRoom.getId());
+
+            // then
+            assertEquals(openChatRoom.getId(), result.getId());
+        }
+    }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
@@ -72,4 +72,31 @@ public class OpenChatRoomControllerTest {
                     .andDo(print());
         }
     }
+
+    @Nested
+    @DisplayName("joinOpenChatRoom 메소드는")
+    class Describe_joinOpenChatRoom {
+        private String password;
+        private Long openChatRoomId;
+
+        @BeforeEach
+        public void setUp() {
+            password = "비밀번호";
+            openChatRoomId = 1L;
+        }
+        @Test
+        @DisplayName("호출이 되면 status 200과 success라는 메세지를 반환한다.")
+        void 호출이_되면_status_200과_success라는_메세지를_반환한다() throws Exception{
+            // given
+            doNothing().when(openChatRoomFacade).joinOpenChatRoom(1L, 1L, "비밀번호");
+
+            // when
+            mockMvc.perform(post("/api/v1/open-chat-rooms/{openChatRoomId}/join", openChatRoomId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"password\":\"비밀번호\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("SUCCESS"))
+                    .andDo(print());
+        }
+    }
 }

--- a/api/src/test/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoomUser/application/service/OpenChatRoomUserServiceImplTest.java
@@ -10,6 +10,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,8 +27,8 @@ public class OpenChatRoomUserServiceImplTest {
     @DisplayName("createOpenChatRoomUser 메소드는")
     class Describe_createOpenChatRoomUser {
         @Test
-        @DisplayName("OpenChatRoomUserServiceImpl의 createOpenChatRoomUser 메소드를 호출한다")
-        void OpenChatRoomUserServiceImpl의_createOpenChatRoomUser메소드를_한번_호출한다() {
+        @DisplayName("OpenChatRoomUserRepository의 createOpenChatRoomUser 메소드를 호출한다")
+        void OpenChatRoomUserRepository의의_createOpenChatRoomUser메소드를_한번_호출한다() {
             // given
             OpenChatRoomUser openChatRoomUser = new OpenChatRoomUser(
                     1L,
@@ -38,6 +41,29 @@ public class OpenChatRoomUserServiceImplTest {
 
             // then
             verify(openChatRoomUserRepository, times(1)).createOpenChatRoomUser(openChatRoomUser);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOpenChatRoomUserByOpenChatRoomIdAndUserId 메소드는")
+    class Describe_countByUserId {
+        @Test
+        @DisplayName("OpenChatRoomUserRepository의 selectOpenChatRoomUserByOpenChatRoomIdAndUserId 메소드를 한번 호출하고 받은 값을 반환한다.")
+        void OpenChatRoomUserRepository의_selectOpenChatRoomUserByOpenChatRoomIdAndUserId메소드를_한번_호출하고_받은_값을_반환한다() {
+            // given
+            Long managerId = 1L;
+            Long openChatRoomId = 2L;
+            when(openChatRoomUserRepository.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomId, managerId)).thenReturn(Optional.of(new OpenChatRoomUser(
+                    openChatRoomId,
+                    managerId
+            )));
+
+            // when
+            Optional<OpenChatRoomUser> openChatRoomUser = openChatRoomUserServiceImpl.getOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomId, managerId);
+
+            // then
+            assertEquals(managerId, openChatRoomUser.get().getUserId());
+            assertEquals(openChatRoomId, openChatRoomUser.get().getOpenChatRoomId());
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapperTest.java
@@ -1,0 +1,42 @@
+package com.jongho.openChatRoomUser.dao.mapper;
+
+import com.jongho.common.dao.BaseMapperTest;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("OpenChatRoomUserMapper 인터페이스")
+public class OpenChatRoomUserMapperTest extends BaseMapperTest {
+    @Autowired
+    private OpenChatRoomUserMapper openChatRoomUserMapper;
+
+    @Nested
+    @DisplayName("createOpenChatRoomUser 메소드는")
+    class Describe_createOpenChatRoomUser {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomUserTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방 유저를 저장한다.")
+        void 오픈채팅방_유저를_생성한다() {
+            // given
+            OpenChatRoomUser openChatRoomUser = new OpenChatRoomUser(
+                    1L,
+                    2L
+            );
+
+            // when
+            openChatRoomUserMapper.createOpenChatRoomUser(openChatRoomUser);
+
+            // then
+            assertEquals(openChatRoomUser, openChatRoomUserMapper.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomUser.getOpenChatRoomId(), openChatRoomUser.getUserId()));
+        }
+    }
+}


### PR DESCRIPTION
## 기능 정의
오픈채팅방에 입장하는 기능입니다.

## 주요 변경 및 추가 사항
오픈채팅방에 유저를 추가하는 Dao 로직을 작성하였습니다.
오픈채팅방에 유저를 추가할때 벨리데이션 검사용 Service로직을 작성하였습니다.
오픈채팅방에 참가하는 usecase를 Facade에 작성하였습니다.
오픈채팅방에 참가하는 엔드포인트를 Controller에 작성하였습니다.

## 테스트
각각의 레이어의 Application, Presentation, Dao에서 테스트코드를 작성하였습니다. 

## 블로커
테스트코드 작성시 MySQL에서는 SQL에서 가져오는 컬럼의 순서에 상관없이 객체랑 맵핑이 되어서 문제가 없었는데
H2 데이터베이스에서는 SQL에서 컬럼의 순서에 따라 맵핑이 되어서 이 부분에서 많이 해맸습니다.

## 미흡한점
