### PR TITLE
참여중인 채팅방 목록 불러오기 API 작성

### DIFF
--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/MyOpenChatRoomListDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/MyOpenChatRoomListDto.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Setter
 @RequiredArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class MyOpenChatRoomListDto {
     public final Long id;
     public final String title;

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/MyOpenChatRoomListDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/MyOpenChatRoomListDto.java
@@ -1,0 +1,20 @@
+package com.jongho.openChatRoom.application.dto.response;
+
+import lombok.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class MyOpenChatRoomListDto {
+    public final Long id;
+    public final String title;
+    public final String notice;
+    public final int maximumCapacity;
+    public final int currentAttendance;
+    public final String createdTime;
+    public final int isManager;
+    public final String categoryName;
+    public final String lastMessage;
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacade.java
@@ -1,7 +1,11 @@
 package com.jongho.openChatRoom.application.facade;
 
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
+
+import java.util.List;
 
 public interface OpenChatRoomFacade {
     public void createOpenChatRoomAndOpenChatRoomUser(Long authUserId, OpenChatRoomCreateDto openChatRoomCreateDto);
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId, int offset);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImpl.java
@@ -6,6 +6,7 @@ import com.jongho.common.exception.AlreadyExistsException;
 import com.jongho.common.exception.CategoryNotFoundException;
 import com.jongho.common.exception.MaxChatRoomsExceededException;
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.application.service.OpenChatRoomService;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.rmi.AlreadyBoundException;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -49,5 +51,12 @@ public class OpenChatRoomFacadeImpl implements OpenChatRoomFacade {
         );
         openChatRoomService.createOpenChatRoom(openChatRoom);
         openChatRoomUserService.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), authUserId));
+    }
+
+    @Override
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId, int offset) {
+        int DEFAULT_OFFSET = 0;
+        if (offset == DEFAULT_OFFSET) return openChatRoomService.getMyOpenChatRoomList(userId);
+        return openChatRoomService.getMyOpenChatRoomList(userId, offset);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -1,7 +1,9 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRoomService {
@@ -9,4 +11,6 @@ public interface OpenChatRoomService {
     public int getOpenChatRoomCountByManagerId(Long managerId);
     public Optional<OpenChatRoom> getOpenChatRoomByManagerIdAndTitle(Long managerId, String title);
     public void incrementOpenChatRoomCurrentAttendance(Long openChatRoomId, int currentAttendance);
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId);
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId, int offset);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -1,10 +1,12 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -26,5 +28,13 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
     @Override
     public Optional<OpenChatRoom> getOpenChatRoomByManagerIdAndTitle(Long managerId, String title) {
         return openChatRoomRepository.selectOneOpenChatRoomByManagerIdAndTitle(managerId, title);
+    }
+    @Override
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId){
+        return openChatRoomRepository.selectMyOpenChatRoomListByUserId(userId);
+    }
+    @Override
+    public List<MyOpenChatRoomListDto> getMyOpenChatRoomList(Long userId, int offset){
+        return openChatRoomRepository.selectMyOpenChatRoomListByUserIdAndOffset(userId, offset);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
+++ b/api/src/main/java/com/jongho/openChatRoom/controller/OpenChatRoomController.java
@@ -5,14 +5,14 @@ import com.jongho.common.response.BaseMessageEnum;
 import com.jongho.common.response.BaseResponseEntity;
 import com.jongho.common.util.threadlocal.AuthenticatedUserThreadLocalManager;
 import com.jongho.openChatRoom.application.dto.request.OpenChatRoomCreateDto;
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.application.facade.OpenChatRoomFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +26,11 @@ public class OpenChatRoomController {
         openChatRoomFacade.createOpenChatRoomAndOpenChatRoomUser(AuthenticatedUserThreadLocalManager.get(), openChatRoomCreateDto);
 
         return BaseResponseEntity.create(BaseMessageEnum.CREATED.getValue());
+    }
+    @GetMapping("/my")
+    public ResponseEntity<BaseResponseEntity<List<MyOpenChatRoomListDto>>> getMyOpenChatRoomList(@RequestParam(value = "offset", defaultValue = "0") int offset){
+        return BaseResponseEntity.ok(
+                openChatRoomFacade.getMyOpenChatRoomList(AuthenticatedUserThreadLocalManager.get(), offset),
+                BaseMessageEnum.SUCCESS.getValue());
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -1,8 +1,11 @@
 package com.jongho.openChatRoom.dao.mapper;
 
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface OpenChatRoomMapper {
@@ -11,4 +14,6 @@ public interface OpenChatRoomMapper {
     public void updateIncrementCurrentCapacity(@Param("id") Long id, @Param("currentAttendance") int currentAttendance);
     public OpenChatRoom selectOneOpenChatRoomById(@Param("id") Long id);
     public OpenChatRoom selectOneOpenChatRoomByManagerIdAndTitle(@Param("managerId") Long managerId, @Param("title") String title);
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserId(@Param("userId") Long userId);
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserIdAndOffset(@Param("userId") Long userId, @Param("offset") int offset);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.jongho.openChatRoom.dao.repository;
 
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -28,4 +30,12 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
     public Optional<OpenChatRoom> selectOneOpenChatRoomByManagerIdAndTitle(Long managerId, String title) {
         return Optional.ofNullable(openChatRoomMapper.selectOneOpenChatRoomByManagerIdAndTitle(managerId, title));
     }
+    @Override
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserId(Long userId){
+        return openChatRoomMapper.selectMyOpenChatRoomListByUserId(userId);
+    };
+    @Override
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserIdAndOffset(Long userId, int offset){
+        return openChatRoomMapper.selectMyOpenChatRoomListByUserIdAndOffset(userId, offset);
+    };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -1,7 +1,10 @@
 package com.jongho.openChatRoom.domain.repository;
 
+import com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRoomRepository {
@@ -9,4 +12,6 @@ public interface OpenChatRoomRepository {
     public void createOpenChatRoom(OpenChatRoom openChatRoom);
     public void updateIncrementCurrentCapacity(Long openChatRoomId, int currentAttendance);
     public Optional<OpenChatRoom> selectOneOpenChatRoomByManagerIdAndTitle(Long managerId, String title);
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserId(Long userId);
+    public List<MyOpenChatRoomListDto> selectMyOpenChatRoomListByUserIdAndOffset(Long userId, int offset);
 }

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -35,4 +35,70 @@
         LIMIT 1
         FOR UPDATE
     </select>
+    <select id="selectMyOpenChatRoomListByUserId" resultType="com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto">
+        SELECT
+            ocr.id,
+            ocr.title,
+            ocr.notice,
+            ocr.maximum_capacity,
+            ocr.current_attendance,
+            ocr.created_time,
+            if(ocr.manager_id = #{userId}, 1, 0) as is_manager,
+            hc.name as category_name,
+            if(oc.id is null, null, oc.message) as last_message,
+            if(oc.id is null, null, oc.created_time) as last_message_time
+        FROM open_chat_rooms as ocr
+        INNER JOIN open_chat_room_users as ocru
+            ON ocru.open_chat_room_id = ocr.id
+            AND ocru.user_id = #{userId}
+            AND ocru.deleted_time is null
+        INNER JOIN hobby_categories as hc
+            ON hc.id = ocr.category_id
+        LEFT JOIN open_chats as oc
+            ON oc.id = (
+                SELECT
+                    id
+                FROM open_chats
+                WHERE open_chat_room_id = ocr.id
+                AND deleted_time is null
+                ORDER BY created_time DESC
+                LIMIT 1
+            )
+        WHERE ocr.deleted_time is null
+        ORDER BY last_message_time DESC, ocr.created_time DESC
+        LIMIT 20
+    </select>
+    <select id="selectMyOpenChatRoomListByUserIdAndOffset" resultType="com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomListDto">
+        SELECT
+            ocr.id,
+            ocr.title,
+            ocr.notice,
+            ocr.maximum_capacity,
+            ocr.current_attendance,
+            ocr.created_time,
+            if(ocr.manager_id = #{userId}, 1, 0) as is_manager,
+            hc.name as category_name,
+            if(oc.id is null, null, oc.message) as last_message,
+            if(oc.id is null, null, oc.created_time) as last_message_time
+        FROM open_chat_rooms as ocr
+        INNER JOIN open_chat_room_users as ocru
+            ON ocru.open_chat_room_id = ocr.id
+            AND ocru.user_id = #{userId}
+            AND ocru.deleted_time is null
+        INNER JOIN hobby_categories as hc
+            ON hc.id = ocr.category_id
+        LEFT JOIN open_chats as oc
+            ON oc.id = (
+                SELECT
+                id
+                FROM open_chats
+                WHERE open_chat_room_id = ocr.id
+                AND deleted_time is null
+                ORDER BY created_time DESC
+                LIMIT 1
+            )
+        WHERE ocr.deleted_time is null
+        ORDER BY last_message_time DESC, ocr.created_time DESC
+        LIMIT 20 OFFSET #{offset}
+    </select>
 </mapper>

--- a/api/src/test/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/facade/OpenChatRoomFacadeImplTest.java
@@ -114,4 +114,43 @@ public class OpenChatRoomFacadeImplTest {
             verify(openChatRoomUserService, times(1)).createOpenChatRoomUser(any());
         }
     }
+
+    @Nested
+    @DisplayName("getMyOpenChatRoomList 메소드는")
+    class Describe_getMyOpenChatRoomList {
+        private Long userId;
+        private int offset;
+        @BeforeEach
+        void setUp() {
+            userId = 1L;
+            offset = 0;
+        }
+
+        @Test
+        @DisplayName("offset이 0이면 userId인자만 받는 getMyOpenChatRoomList를 호출한다")
+        void offset이_0이면_userId인자만_받는_getMyOpenChatRoomList를_호출한다() {
+            // given
+            when(openChatRoomService.getMyOpenChatRoomList(userId)).thenReturn(null);
+
+            // when
+            openChatRoomFacadeImpl.getMyOpenChatRoomList(userId, offset);
+
+            // then
+            verify(openChatRoomService, times(1)).getMyOpenChatRoomList(userId);
+        }
+
+        @Test
+        @DisplayName("offset이 0이 아니면 userId와 offset을 인자로 받는 getMyOpenChatRoomList를 호출한다")
+        void offset이_0이_아니면_userId와_offset을_인자로_받는_getMyOpenChatRoomList를_호출한다() {
+            // given
+            offset = 1;
+            when(openChatRoomService.getMyOpenChatRoomList(userId, offset)).thenReturn(null);
+
+            // when
+            openChatRoomFacadeImpl.getMyOpenChatRoomList(userId, offset);
+
+            // then
+            verify(openChatRoomService, times(1)).getMyOpenChatRoomList(userId, offset);
+        }
+    }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
@@ -25,8 +25,8 @@ public class OpenChatRoomServiceImplTest {
     @DisplayName("createOpenChatRoom 메소드는")
     class Describe_createOpenChatRoom {
         @Test
-        @DisplayName("OpenChatRoomServiceImpl의 createOpenChatRoom 메소드를 호출한다")
-        void OpenChatRoomServiceImpl의_createOpenChatRoom메소드를_한번_호출한다() {
+        @DisplayName("OpenChatRoomRepository의 createOpenChatRoom 메소드를 호출한다")
+        void OpenChatRoomRepositoryl의_createOpenChatRoom메소드를_한번_호출한다() {
             // given
             OpenChatRoom openChatRoom = new OpenChatRoom(
                     "타이틀",
@@ -50,8 +50,8 @@ public class OpenChatRoomServiceImplTest {
     @DisplayName("countByManagerId 메소드는")
     class Describe_countByManagerId {
         @Test
-        @DisplayName("OpenChatRoomServiceImpl의 countByManagerId 메소드를 호출해서 받은 count를 반환한다")
-        void OpenChatRoomServiceImpl의_countByManagerId메소드를_한번_호출해서_받은_count를_반환한다() {
+        @DisplayName("OpenChatRoomRepository의 countByManagerId 메소드를 호출해서 받은 count를 반환한다")
+        void OpenChatRoomRepository의_countByManagerId메소드를_한번_호출해서_받은_count를_반환한다() {
             // given
             Long managerId = 1L;
             when(openChatRoomRepository.countByManagerId(managerId)).thenReturn(5);
@@ -62,6 +62,41 @@ public class OpenChatRoomServiceImplTest {
             // then
             verify(openChatRoomRepository, times(1)).countByManagerId(managerId);
             assertEquals(5, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyOpenChatRoomList 메소드는")
+    class Describe_getMyOpenChatRoomList {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectMyOpenChatRoomListByUserId 메소드를 호출한다")
+        void OpenChatRoomRepository의_selectMyOpenChatRoomListByUserId메소드를_한번_호출한다() {
+            // given
+            Long userId = 1L;
+
+            // when
+            openChatRoomServiceImpl.getMyOpenChatRoomList(userId);
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectMyOpenChatRoomListByUserId(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyOpenChatRoomList 메소드는")
+    class Describe_getMyOpenChatRoomListWithOffset {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectMyOpenChatRoomListByUserIdAndOffset 메소드를 호출한다")
+        void OpenChatRoomRepository의_selectMyOpenChatRoomListByUserIdAndOffset메소드를_한번_호출한다() {
+            // given
+            Long userId = 1L;
+            int offset = 1;
+
+            // when
+            openChatRoomServiceImpl.getMyOpenChatRoomList(userId, offset);
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectMyOpenChatRoomListByUserIdAndOffset(userId, offset);
         }
     }
 }


### PR DESCRIPTION
## 기능 정의
참여중인 채팅방 목록 불러오기

## 주요 변경 및 추가 사항
참여중인 채팅방 목록 불러오기 위한 Application, Dao, Presentation관련 로직 작성

## 테스트
참여중인 채팅방 목록 불러오기 위한 Application, Dao, Presentation관련 테스트코드 작성

## 블로커
리스트를 불러오는 쿼리를 작성할때 특정 컬럼의 카디널리티가 높은 OpenChatRoomUser를 드라이빙 테이블로 작성하는게 맞는것 같은데
엔드포인트 도메인이 OpenChatRoom이라서 드라이빙테이블로 OpenChatRoom.xml에 작성하였는데 이부분은 피드백을 받아봐야 할것같습니다.

그리고 여러 조인이 들어갔는데 LEFT JOIN에서 서브쿼리가 들어간 부분이 있는데 저번 피드백때 서브쿼리보다는 쿼리를 나누고 어플리케이션에서 조합하는게 더 나을것같다는 피드백을 받았는데 이렇게 리스트로 들어있는 다중의 데이터를 어플리케이션에서 조합하려면 1+N개의 쿼리가 들어가는데 이부분도 어플리케이션에서 조합해야하는지 피드백 받아봐야 알것같습니다.

## 미흡한점
read의 목적인 보여주기위한 데이터를 이전직장에서 작성하던데로 쿼리를 작성해봤는데 아직은 어플리케이션에서 조합해야 하는 상황과
한방쿼리로 작성해야하는 상황에 대한 식별이 어려운것이 미흡한점 입니다.
