### PR TITLE
웹소켓 설정 작성 및 웹소켓 핸드셰이크 인터셉터 작성

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'org.mindrot:jbcrypt:0.4'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'org.mindrot:jbcrypt:0.4'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'org.mindrot:jbcrypt:0.4'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
+++ b/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
@@ -18,8 +18,8 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final WebSocketOpenChatRoomHandler webSocketOpenChatRoomHandler;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketOpenChatRoomHandler, "/openChatRoom")
-                .addHandler(webSocketOpenChatHandler, "/openChat")
+        registry.addHandler(webSocketOpenChatRoomHandler, "/open-chat-rooms")
+                .addHandler(webSocketOpenChatHandler, "/open-chats")
                 .addInterceptors(webSocketAuthInterceptor)
                 .setAllowedOrigins("*");
     }

--- a/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
+++ b/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.jongho.common.config;
+
+import com.jongho.common.interceptor.WebSocketAuthInterceptor;
+import com.jongho.openChat.handler.WebSocketOpenChatHandler;
+import com.jongho.openChatRoom.handler.WebSocketOpenChatRoomHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final WebSocketOpenChatHandler webSocketOpenChatHandler;
+    private final WebSocketOpenChatRoomHandler webSocketOpenChatRoomHandler;
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketOpenChatRoomHandler, "/openChatRoom")
+                .addHandler(webSocketOpenChatHandler, "/openChat")
+                .addInterceptors(webSocketAuthInterceptor)
+                .setAllowedOrigins("*");
+    }
+}

--- a/api/src/main/java/com/jongho/common/database/redis/RedisService.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisService.java
@@ -1,0 +1,11 @@
+package com.jongho.common.database.redis;
+
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.List;
+
+public interface RedisService {
+    public void publish(String channel, String message);
+    public void subscribe(String channel, WebSocketSession session);
+    public void subscribe(List<String> channel, WebSocketSession session);
+}

--- a/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
@@ -1,0 +1,50 @@
+package com.jongho.common.database.redis;
+
+import com.jongho.common.util.redis.BaseRedisTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RedisServiceImpl implements RedisService{
+    private final BaseRedisTemplate baseRedisTemplate;
+    public void publish(String channel, String message) {
+        baseRedisTemplate.publish(channel, message);
+    }
+    public void subscribe(String channel, WebSocketSession session) {
+        baseRedisTemplate.subscribe(channel, getMessageHandler(session));
+    }
+    public void subscribe(List<String> channel, WebSocketSession session) {
+        baseRedisTemplate.subscribe(channel, getMessageHandler(session));
+    }
+
+    private RedisMessageHandler getMessageHandler(WebSocketSession session) {
+        return new RedisMessageHandler(session);
+    }
+}
+
+@Log4j2
+@RequiredArgsConstructor
+class RedisMessageHandler implements MessageListener {
+    private final WebSocketSession session;
+
+    @Override
+    public void onMessage(@NotNull Message message, byte[] pattern) {
+        try {
+            if(session.isOpen()){
+                session.sendMessage(new TextMessage(new String(message.getBody())));
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/com/jongho/common/interceptor/WebSocketAuthInterceptor.java
+++ b/api/src/main/java/com/jongho/common/interceptor/WebSocketAuthInterceptor.java
@@ -1,0 +1,84 @@
+package com.jongho.common.interceptor;
+
+import com.google.gson.Gson;
+import com.jongho.common.exception.UnAuthorizedException;
+import com.jongho.common.response.BaseResponseEntity;
+import com.jongho.common.util.jwt.AccessPayload;
+import com.jongho.common.util.jwt.JwtUtil;
+import com.jongho.common.util.threadlocal.AuthenticatedUserThreadLocalManager;
+import com.jongho.user.application.service.AuthUserService;
+import com.jongho.user.application.service.UserService;
+import com.jongho.user.domain.model.AuthUser;
+import com.jongho.user.domain.model.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+    private final JwtUtil jwtUtil;
+    private final AuthUserService authUserService;
+    private final UserService userService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest) {
+            HttpServletRequest servletRequest = ((ServletServerHttpRequest) request).getServletRequest();
+            HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+
+            String accessToken = servletRequest.getHeader("Authorization");
+            if (accessToken != null) {
+                return handleValidAccessToken(accessToken, servletRequest, servletResponse, attributes);
+            } else {
+                return handleInvalidAccessToken(servletResponse, "토큰이 존재하지 않습니다.");
+            }
+
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+    }
+
+    private boolean handleValidAccessToken(String accessToken, HttpServletRequest request, HttpServletResponse response, Map<String, Object> attributes) throws IOException {
+        try {
+            AccessPayload accessPayload = jwtUtil.validateAccessToken(accessToken);
+            AuthUser authUser = authUserService.getAuthUser(accessPayload.getUserId()).orElseThrow(() -> new UnAuthorizedException("존재하지 않는 유저입니다."));
+
+            User user = userService.getUserById(authUser.getUserId()).orElseThrow(() -> new UnAuthorizedException("존재하지 않는 유저입니다."));
+            attributes.put("userId", user.getId());
+
+            return true;
+        } catch (UnAuthorizedException e) {
+
+            return handleInvalidAccessToken(response, e.getMessage());
+        }
+    }
+
+    private boolean handleInvalidAccessToken(HttpServletResponse response, String errorMessage) throws IOException {
+        String result = new Gson().toJson(BaseResponseEntity.fail(HttpStatus.UNAUTHORIZED, errorMessage).getBody());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json; charset=UTF-8");
+        PrintWriter writer = response.getWriter();
+        writer.println(result);
+
+        return false;
+    }
+}

--- a/api/src/main/java/com/jongho/common/util/date/DateUtil.java
+++ b/api/src/main/java/com/jongho/common/util/date/DateUtil.java
@@ -1,0 +1,12 @@
+package com.jongho.common.util.date;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+    public static LocalDate convertStringToDate(String stringDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return LocalDate.parse(stringDate, formatter);
+    }
+}

--- a/api/src/main/java/com/jongho/common/util/date/DateUtil.java
+++ b/api/src/main/java/com/jongho/common/util/date/DateUtil.java
@@ -1,12 +1,12 @@
 package com.jongho.common.util.date;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class DateUtil {
-    public static LocalDate convertStringToDate(String stringDate) {
+    public static LocalDateTime convertStringToDate(String stringDate) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-        return LocalDate.parse(stringDate, formatter);
+        return LocalDateTime.parse(stringDate, formatter);
     }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -6,6 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 public class BaseRedisTemplate {
@@ -19,6 +23,22 @@ public class BaseRedisTemplate {
         String jsonValue = stringRedisTemplate.opsForValue().get(key);
 
         return toObject(jsonValue, valueType);
+    }
+
+    public <T> List<T> getAllListData(String key, Class<T> valueType) {
+        List<String> jsonValue = stringRedisTemplate.opsForList().range(key, 0, -1);
+        if(jsonValue == null){
+            return null;
+        }
+        return mappingToElement(jsonValue, valueType);
+    }
+
+    public <T> List<T> getListData(String key, Class<T> valueType, int offset, int limit) {
+        List<String> jsonValue = stringRedisTemplate.opsForList().range(key, offset, limit);
+        if(jsonValue == null){
+            return null;
+        }
+        return mappingToElement(jsonValue, valueType);
     }
 
     public <T> T toObject(String json, Class<T> valueType) {
@@ -35,5 +55,9 @@ public class BaseRedisTemplate {
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }
+    }
+
+    private <T> List<T> mappingToElement(Collection<String> jsonList, Class<T> valueType){
+        return jsonList.stream().map(json -> toObject(json, valueType)).collect(Collectors.toList());
     }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -3,13 +3,12 @@ package com.jongho.common.util.redis;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jongho.common.exception.MyJsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
@@ -74,6 +73,20 @@ public class BaseRedisTemplate {
             return null;
         }
         return mapToObject(map, valueType);
+    }
+
+    public void publish(String channel, String message) {
+        stringRedisTemplate.convertAndSend(channel, message);
+    }
+
+    public void subscribe(String channel, MessageListener messageListener) {
+        Objects.requireNonNull(stringRedisTemplate.getConnectionFactory()).getConnection().subscribe(messageListener, channel.getBytes());
+    }
+
+    public void subscribe(List<String> channel, MessageListener messageListener) {
+        for(String c : channel) {
+            Objects.requireNonNull(stringRedisTemplate.getConnectionFactory()).getConnection().subscribe(messageListener, c.getBytes());
+        }
     }
 
     public <T> T toObject(String json, Class<T> valueType) {

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -7,7 +7,9 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
@@ -21,7 +23,9 @@ public class BaseRedisTemplate {
 
     public <T> T getData(String key, Class<T> valueType) {
         String jsonValue = stringRedisTemplate.opsForValue().get(key);
-
+        if(jsonValue == null){
+            return null;
+        }
         return toObject(jsonValue, valueType);
     }
 
@@ -33,6 +37,25 @@ public class BaseRedisTemplate {
         return mappingToElement(jsonValue, valueType);
     }
 
+    public <T> List<T> getReverseRangeAllListData(String key, Class<T> valueType) {
+        List<String> jsonValue = stringRedisTemplate.opsForList().range(key, 0, -1);
+        if(jsonValue == null){
+            return null;
+        }
+        List<T> result = mappingToElement(jsonValue, valueType);
+        Collections.reverse(result);
+
+        return result;
+    }
+
+    public <T> void setAllListData(String key, List<T> value) {
+        stringRedisTemplate.opsForList().rightPushAll(key, value.stream().map(this::toJson).collect(Collectors.toList()));
+    }
+
+    public <T> void setListData(String key, T value) {
+        stringRedisTemplate.opsForList().rightPush(key, toJson(value));
+    }
+
     public <T> List<T> getListData(String key, Class<T> valueType, int offset, int limit) {
         List<String> jsonValue = stringRedisTemplate.opsForList().range(key, offset, limit);
         if(jsonValue == null){
@@ -41,9 +64,29 @@ public class BaseRedisTemplate {
         return mappingToElement(jsonValue, valueType);
     }
 
+    public void setHashData(String key, Map<String, String> value) {
+        stringRedisTemplate.opsForHash().putAll(key, value);
+    }
+
+    public <T> T getHashData(String key, Class<T> valueType) {
+        Map<Object, Object> map = stringRedisTemplate.opsForHash().entries(key);
+        if(map.size() == 0){
+            return null;
+        }
+        return mapToObject(map, valueType);
+    }
+
     public <T> T toObject(String json, Class<T> valueType) {
         try {
             return objectMapper.readValue(json, valueType);
+        }catch (Exception e) {
+            throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
+        }
+    }
+
+    public <T> T mapToObject(Map<Object, Object> map, Class<T> valueType) {
+        try {
+            return objectMapper.convertValue(map, valueType);
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }

--- a/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
+++ b/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
@@ -13,4 +13,7 @@ public class RedisKeyGeneration {
     public static String getChatRoomMessageKey(Long openChatRoomId) {
         return "chatRooms:" + openChatRoomId + ":chats";
     }
+    public static String getLastMessageKey(Long openChatRoomId) {
+        return "chatRooms:" + openChatRoomId + ":lastMessage";
+    }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
+++ b/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
@@ -16,4 +16,7 @@ public class RedisKeyGeneration {
     public static String getLastMessageKey(Long openChatRoomId) {
         return "chatRooms:" + openChatRoomId + ":lastMessage";
     }
+    public static String getChatRoomUserListKey(Long openChatRoomId) {
+        return "chatRooms:" + openChatRoomId + ":users";
+    }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
+++ b/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
@@ -1,0 +1,16 @@
+package com.jongho.common.util.redis;
+
+public class RedisKeyGeneration {
+    public static String getChatRoomConnectionInfoKey(Long userId, Long openChatRoomId) {
+        return "users:" + userId + ":chatRooms:" + openChatRoomId + ":connectionInfo";
+    }
+    public static String getJoinedChatRoomsKey(Long userId) {
+        return "users:" + userId + ":chatRooms";
+    }
+    public static String getChatRoomKey(Long openChatRoomId) {
+        return "chatRooms:" + openChatRoomId;
+    }
+    public static String getChatRoomMessageKey(Long openChatRoomId) {
+        return "chatRooms:" + openChatRoomId + ":chats";
+    }
+}

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseMessageTypeEnum.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseMessageTypeEnum.java
@@ -1,0 +1,18 @@
+package com.jongho.common.util.websocket;
+
+public enum BaseMessageTypeEnum {
+    SEND("SEND"),
+    RECEIVE("RECEIVE"),
+    JOIN("JOIN"),
+    LEAVE("LEAVE"),
+    ERROR("ERROR");
+    private final String value;
+
+    BaseMessageTypeEnum (String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
@@ -1,5 +1,7 @@
 package com.jongho.common.util.websocket;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jongho.common.exception.MyJsonProcessingException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -10,8 +12,13 @@ import lombok.ToString;
 public class BaseWebSocketMessage<T> {
     private final BaseMessageTypeEnum type;
     private final T data;
+    public static ObjectMapper objectMapper = new ObjectMapper();
 
-    public static <T> BaseWebSocketMessage<T> join(T data) {
-        return new BaseWebSocketMessage<T>(BaseMessageTypeEnum.JOIN, data);
+    public static <T> String join(T data) {
+        try {
+            return objectMapper.writeValueAsString(new BaseWebSocketMessage<T>(BaseMessageTypeEnum.JOIN, data));
+        }catch (Exception e) {
+            throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
+        }
     }
 }

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
@@ -1,0 +1,17 @@
+package com.jongho.common.util.websocket;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class BaseWebSocketMessage<T> {
+    private final BaseMessageTypeEnum type;
+    private final T data;
+
+    public static <T> BaseWebSocketMessage<T> join(T data) {
+        return new BaseWebSocketMessage<T>(BaseMessageTypeEnum.JOIN, data);
+    }
+}

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
@@ -14,7 +14,7 @@ public class BaseWebSocketMessage<T> {
     private final T data;
     public static ObjectMapper objectMapper = new ObjectMapper();
 
-    public static <T> String join(T data) {
+    public static <T> String of(T data) {
         try {
             return objectMapper.writeValueAsString(new BaseWebSocketMessage<T>(BaseMessageTypeEnum.JOIN, data));
         }catch (Exception e) {

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
@@ -2,8 +2,10 @@ package com.jongho.openChat.application.service;
 
 import com.jongho.openChat.domain.model.OpenChat;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRedisService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
+    public List<OpenChat> getOpenChatListByOpenChatRoomId(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+
+import java.util.Optional;
+
+public interface OpenChatRedisService {
+    public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
@@ -5,6 +5,7 @@ import com.jongho.openChat.domain.repository.OpenChatRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -15,5 +16,9 @@ public class OpenChatRedisServiceImpl implements OpenChatRedisService {
     @Override
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId){
         return openChatRedisRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
+    };
+    @Override
+    public List<OpenChat> getOpenChatListByOpenChatRoomId(Long openChatRoomId){
+        return openChatRedisRepository.selectOpenChatListByChatRoomId(openChatRoomId);
     };
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
@@ -1,0 +1,19 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatRedisServiceImpl implements OpenChatRedisService {
+    private final OpenChatRedisRepository openChatRedisRepository;
+
+    @Override
+    public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId){
+        return openChatRedisRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
+    };
+}

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
@@ -2,8 +2,10 @@ package com.jongho.openChat.application.service;
 
 import com.jongho.openChat.domain.model.OpenChat;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
+    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface OpenChatService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
-    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime);
+    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+
+import java.util.Optional;
+
+public interface OpenChatService {
+    public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
@@ -1,0 +1,18 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatServiceImpl implements OpenChatService{
+    private final OpenChatRepository openChatRepository;
+
+    public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId){
+        return openChatRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
+    };
+}

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
@@ -16,8 +16,8 @@ public class OpenChatServiceImpl implements OpenChatService{
         return openChatRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
     };
     @Override
-    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime){
-        return openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime);
+    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit){
+        return openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
     }
 
 

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
@@ -11,8 +11,14 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OpenChatServiceImpl implements OpenChatService{
     private final OpenChatRepository openChatRepository;
-
+    @Override
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId){
         return openChatRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
     };
+    @Override
+    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime){
+        return openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime);
+    }
+
+
 }

--- a/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
+++ b/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.dao.mapper;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OpenChatMapper {
+    public OpenChat selectLastOpenChatByChatRoomId(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
+++ b/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
@@ -9,5 +9,6 @@ public interface OpenChatMapper {
     public OpenChat selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(
             @Param("openChatRoomId") Long openChatRoomId,
-            @Param("lastExitTime") String lastExitTime);
+            @Param("lastExitTime") String lastExitTime,
+            @Param("limit") int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
+++ b/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
@@ -2,8 +2,12 @@ package com.jongho.openChat.dao.mapper;
 
 import com.jongho.openChat.domain.model.OpenChat;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface OpenChatMapper {
     public OpenChat selectLastOpenChatByChatRoomId(Long openChatRoomId);
+    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(
+            @Param("openChatRoomId") Long openChatRoomId,
+            @Param("lastExitTime") String lastExitTime);
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.jongho.openChat.dao.repository;
+
+import com.jongho.common.util.redis.BaseRedisTemplate;
+import com.jongho.common.util.redis.RedisKeyGeneration;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OpenChatRedisRepositoryImpl implements OpenChatRedisRepository {
+    private final BaseRedisTemplate baseRedisTemplate;
+
+    @Override
+    public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId){
+        return Optional.ofNullable(baseRedisTemplate.getData(
+                RedisKeyGeneration.getLastMessageKey(openChatRoomId),
+                OpenChat.class));
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.jongho.openChat.domain.repository.OpenChatRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -20,4 +21,10 @@ public class OpenChatRedisRepositoryImpl implements OpenChatRedisRepository {
                 RedisKeyGeneration.getLastMessageKey(openChatRoomId),
                 OpenChat.class));
     }
+    @Override
+    public List<OpenChat> selectOpenChatListByChatRoomId(Long openChatRoomId){
+        return baseRedisTemplate.getReverseRangeAllListData(
+                RedisKeyGeneration.getChatRoomMessageKey(openChatRoomId),
+                OpenChat.class);
+    };
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.jongho.openChat.dao.repository;
+
+import com.jongho.openChat.dao.mapper.OpenChatMapper;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OpenChatRepositoryImpl implements OpenChatRepository {
+    private final OpenChatMapper openChatMapper;
+
+    @Override
+    public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId) {
+        return Optional.ofNullable(openChatMapper.selectLastOpenChatByChatRoomId(openChatRoomId));
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
@@ -18,7 +18,7 @@ public class OpenChatRepositoryImpl implements OpenChatRepository {
         return Optional.ofNullable(openChatMapper.selectLastOpenChatByChatRoomId(openChatRoomId));
     }
     @Override
-    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime) {
-        return openChatMapper.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime);
+    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit) {
+        return openChatMapper.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
     }
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
@@ -17,4 +17,8 @@ public class OpenChatRepositoryImpl implements OpenChatRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId) {
         return Optional.ofNullable(openChatMapper.selectLastOpenChatByChatRoomId(openChatRoomId));
     }
+    @Override
+    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime) {
+        return openChatMapper.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime);
+    }
 }

--- a/api/src/main/java/com/jongho/openChat/domain/OpenChat.java
+++ b/api/src/main/java/com/jongho/openChat/domain/OpenChat.java
@@ -1,0 +1,39 @@
+package com.jongho.openChat.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class OpenChat {
+    private final Long id;
+    private final Long senderId;
+    private final Long openChatRoomId;
+    private final String message;
+    private final int type;
+    private final int isDeleted;
+    private final String deletedTime;
+    private final String createdTime;
+
+    @JsonCreator
+    public OpenChat(
+            @JsonProperty("id") Long id,
+            @JsonProperty("senderId") Long senderId,
+            @JsonProperty("openChatRoomId") Long openChatRoomId,
+            @JsonProperty("message") String message,
+            @JsonProperty("type") int type,
+            @JsonProperty("isDeleted") int isDeleted,
+            @JsonProperty("deletedTime") String deletedTime,
+            @JsonProperty("createdTime") String createdTime) {
+        this.id = id;
+        this.senderId = senderId;
+        this.openChatRoomId = openChatRoomId;
+        this.message = message;
+        this.type = type;
+        this.isDeleted = isDeleted;
+        this.deletedTime = deletedTime;
+        this.createdTime = createdTime;
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/domain/model/OpenChat.java
+++ b/api/src/main/java/com/jongho/openChat/domain/model/OpenChat.java
@@ -1,4 +1,4 @@
-package com.jongho.openChat.domain;
+package com.jongho.openChat.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
@@ -2,8 +2,10 @@ package com.jongho.openChat.domain.repository;
 
 import com.jongho.openChat.domain.model.OpenChat;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRedisRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
+    public List<OpenChat> selectOpenChatListByChatRoomId(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.domain.repository;
+
+import com.jongho.openChat.domain.model.OpenChat;
+
+import java.util.Optional;
+
+public interface OpenChatRedisRepository {
+    public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.domain.repository;
+
+import com.jongho.openChat.domain.model.OpenChat;
+
+import java.util.Optional;
+
+public interface OpenChatRepository {
+    public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface OpenChatRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
-    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime);
+    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
@@ -2,8 +2,10 @@ package com.jongho.openChat.domain.repository;
 
 import com.jongho.openChat.domain.model.OpenChat;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
+    public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime);
 }

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -1,0 +1,19 @@
+package com.jongho.openChat.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketOpenChatHandler extends TextWebSocketHandler {
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomConnectionInfo.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomConnectionInfo.java
@@ -1,0 +1,26 @@
+package com.jongho.openChatRoom.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class OpenChatRoomConnectionInfo {
+    private int active;
+    private int unReadMessageCount;
+    private int lastExitTime;
+
+    @JsonCreator
+    public OpenChatRoomConnectionInfo(
+            @JsonProperty("active") int active,
+            @JsonProperty("unReadMessageCount") int unReadMessageCount,
+            @JsonProperty("lastExitTime") int lastExitTime) {
+        this.active = active;
+        this.unReadMessageCount = unReadMessageCount;
+        this.lastExitTime = lastExitTime;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -1,6 +1,6 @@
 package com.jongho.openChatRoom.application.dto.response;
 
-import com.jongho.openChat.domain.OpenChat;
+import com.jongho.openChat.domain.model.OpenChat;
 import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
 import lombok.*;
 

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -1,6 +1,7 @@
 package com.jongho.openChatRoom.application.dto.response;
 
 import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
 import lombok.*;
 
@@ -20,6 +21,17 @@ public class OpenChatRoomDto {
     private final String createdTime;
     private OpenChat lastChat;
     private RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo;
+
+    public OpenChatRoomDto(RedisOpenChatRoom redisOpenChatRoom) {
+        this.id = redisOpenChatRoom.getId();
+        this.title = redisOpenChatRoom.getTitle();
+        this.notice = redisOpenChatRoom.getNotice();
+        this.managerId = redisOpenChatRoom.getManagerId();
+        this.categoryId = redisOpenChatRoom.getCategoryId();
+        this.maximumCapacity = redisOpenChatRoom.getMaximumCapacity();
+        this.currentAttendance = redisOpenChatRoom.getCurrentAttendance();
+        this.createdTime = redisOpenChatRoom.getCreatedTime();
+    }
 
     public void setOpenChat(OpenChat lastChat) {
         this.lastChat = lastChat;

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -1,17 +1,14 @@
 package com.jongho.openChatRoom.application.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jongho.openChat.domain.OpenChat;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
-import java.util.List;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import lombok.*;
 
 @Getter
 @ToString
 @EqualsAndHashCode(of = "id")
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class OpenChatRoomDto {
     private final Long id;
     private final String title;
@@ -22,55 +19,13 @@ public class OpenChatRoomDto {
     private final int currentAttendance;
     private final String createdTime;
     private OpenChat lastChat;
-    private OpenChatRoomConnectionInfo openChatRoomConnectionInfo;
-
-    @JsonCreator
-    public OpenChatRoomDto(
-            @JsonProperty("id") Long id,
-            @JsonProperty("title") String title,
-            @JsonProperty("notice") String notice,
-            @JsonProperty("managerId") Long managerId,
-            @JsonProperty("categoryId") Long categoryId,
-            @JsonProperty("maximumCapacity") int maximumCapacity,
-            @JsonProperty("currentAttendance") int currentAttendance,
-            @JsonProperty("createdTime") String createdTime) {
-        this.id = id;
-        this.title = title;
-        this.notice = notice;
-        this.managerId = managerId;
-        this.categoryId = categoryId;
-        this.maximumCapacity = maximumCapacity;
-        this.currentAttendance = currentAttendance;
-        this.createdTime = createdTime;
-    }
-
-    @JsonCreator
-    public OpenChatRoomDto(
-            @JsonProperty("id") Long id,
-            @JsonProperty("title") String title,
-            @JsonProperty("notice") String notice,
-            @JsonProperty("managerId") Long managerId,
-            @JsonProperty("categoryId") Long categoryId,
-            @JsonProperty("maximumCapacity") int maximumCapacity,
-            @JsonProperty("currentAttendance") int currentAttendance,
-            @JsonProperty("createdTime") String createdTime,
-            @JsonProperty("openChat") OpenChat lastChat) {
-        this.id = id;
-        this.title = title;
-        this.notice = notice;
-        this.managerId = managerId;
-        this.categoryId = categoryId;
-        this.maximumCapacity = maximumCapacity;
-        this.currentAttendance = currentAttendance;
-        this.createdTime = createdTime;
-        this.lastChat = lastChat;
-    }
+    private RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo;
 
     public void setOpenChat(OpenChat lastChat) {
         this.lastChat = lastChat;
     }
 
-    public void setOpenChatRoomConnectionInfo(OpenChatRoomConnectionInfo openChatRoomConnectionInfo) {
-        this.openChatRoomConnectionInfo = openChatRoomConnectionInfo;
+    public void setRedisOpenChatRoomConnectionInfo(RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
+        this.redisOpenChatRoomConnectionInfo = redisOpenChatRoomConnectionInfo;
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -23,6 +23,7 @@ public class OpenChatRoomDto {
     private final String createdTime;
     private OpenChat openChat;
     private List<Long> openChatRoomUserIds;
+    private OpenChatRoomConnectionInfo openChatRoomConnectionInfo;
 
     @JsonCreator
     public OpenChatRoomDto(
@@ -74,5 +75,9 @@ public class OpenChatRoomDto {
 
     public void setOpenChatRoomUserIds(List<Long> openChatRoomUserIds) {
         this.openChatRoomUserIds = openChatRoomUserIds;
+    }
+
+    public void setOpenChatRoomConnectionInfo(OpenChatRoomConnectionInfo openChatRoomConnectionInfo) {
+        this.openChatRoomConnectionInfo = openChatRoomConnectionInfo;
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -1,8 +1,8 @@
 package com.jongho.openChatRoom.application.dto.response;
 
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 import lombok.*;
 
 @Getter
@@ -20,24 +20,24 @@ public class OpenChatRoomDto {
     private final int currentAttendance;
     private final String createdTime;
     private OpenChat lastChat;
-    private RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo;
+    private CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo;
 
-    public OpenChatRoomDto(RedisOpenChatRoom redisOpenChatRoom) {
-        this.id = redisOpenChatRoom.getId();
-        this.title = redisOpenChatRoom.getTitle();
-        this.notice = redisOpenChatRoom.getNotice();
-        this.managerId = redisOpenChatRoom.getManagerId();
-        this.categoryId = redisOpenChatRoom.getCategoryId();
-        this.maximumCapacity = redisOpenChatRoom.getMaximumCapacity();
-        this.currentAttendance = redisOpenChatRoom.getCurrentAttendance();
-        this.createdTime = redisOpenChatRoom.getCreatedTime();
+    public OpenChatRoomDto(CachedOpenChatRoom cachedOpenChatRoom) {
+        this.id = cachedOpenChatRoom.getId();
+        this.title = cachedOpenChatRoom.getTitle();
+        this.notice = cachedOpenChatRoom.getNotice();
+        this.managerId = cachedOpenChatRoom.getManagerId();
+        this.categoryId = cachedOpenChatRoom.getCategoryId();
+        this.maximumCapacity = cachedOpenChatRoom.getMaximumCapacity();
+        this.currentAttendance = cachedOpenChatRoom.getCurrentAttendance();
+        this.createdTime = cachedOpenChatRoom.getCreatedTime();
     }
 
     public void setOpenChat(OpenChat lastChat) {
         this.lastChat = lastChat;
     }
 
-    public void setRedisOpenChatRoomConnectionInfo(RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
-        this.redisOpenChatRoomConnectionInfo = redisOpenChatRoomConnectionInfo;
+    public void setCachedOpenChatRoomConnectionInfo(CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo) {
+        this.cachedOpenChatRoomConnectionInfo = cachedOpenChatRoomConnectionInfo;
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -21,8 +21,7 @@ public class OpenChatRoomDto {
     private final int maximumCapacity;
     private final int currentAttendance;
     private final String createdTime;
-    private OpenChat openChat;
-    private List<Long> openChatRoomUserIds;
+    private OpenChat lastChat;
     private OpenChatRoomConnectionInfo openChatRoomConnectionInfo;
 
     @JsonCreator
@@ -55,8 +54,7 @@ public class OpenChatRoomDto {
             @JsonProperty("maximumCapacity") int maximumCapacity,
             @JsonProperty("currentAttendance") int currentAttendance,
             @JsonProperty("createdTime") String createdTime,
-            @JsonProperty("openChat") OpenChat openChat,
-            @JsonProperty("openChatRoomUserIds") List<Long> openChatRoomUserIds) {
+            @JsonProperty("openChat") OpenChat lastChat) {
         this.id = id;
         this.title = title;
         this.notice = notice;
@@ -65,16 +63,11 @@ public class OpenChatRoomDto {
         this.maximumCapacity = maximumCapacity;
         this.currentAttendance = currentAttendance;
         this.createdTime = createdTime;
-        this.openChat = openChat;
-        this.openChatRoomUserIds = openChatRoomUserIds;
+        this.lastChat = lastChat;
     }
 
-    public void setOpenChat(OpenChat openChat) {
-        this.openChat = openChat;
-    }
-
-    public void setOpenChatRoomUserIds(List<Long> openChatRoomUserIds) {
-        this.openChatRoomUserIds = openChatRoomUserIds;
+    public void setOpenChat(OpenChat lastChat) {
+        this.lastChat = lastChat;
     }
 
     public void setOpenChatRoomConnectionInfo(OpenChatRoomConnectionInfo openChatRoomConnectionInfo) {

--- a/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/dto/response/OpenChatRoomDto.java
@@ -1,0 +1,78 @@
+package com.jongho.openChatRoom.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jongho.openChat.domain.OpenChat;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+@EqualsAndHashCode(of = "id")
+public class OpenChatRoomDto {
+    private final Long id;
+    private final String title;
+    private final String notice;
+    private final Long managerId;
+    private final Long categoryId;
+    private final int maximumCapacity;
+    private final int currentAttendance;
+    private final String createdTime;
+    private OpenChat openChat;
+    private List<Long> openChatRoomUserIds;
+
+    @JsonCreator
+    public OpenChatRoomDto(
+            @JsonProperty("id") Long id,
+            @JsonProperty("title") String title,
+            @JsonProperty("notice") String notice,
+            @JsonProperty("managerId") Long managerId,
+            @JsonProperty("categoryId") Long categoryId,
+            @JsonProperty("maximumCapacity") int maximumCapacity,
+            @JsonProperty("currentAttendance") int currentAttendance,
+            @JsonProperty("createdTime") String createdTime) {
+        this.id = id;
+        this.title = title;
+        this.notice = notice;
+        this.managerId = managerId;
+        this.categoryId = categoryId;
+        this.maximumCapacity = maximumCapacity;
+        this.currentAttendance = currentAttendance;
+        this.createdTime = createdTime;
+    }
+
+    @JsonCreator
+    public OpenChatRoomDto(
+            @JsonProperty("id") Long id,
+            @JsonProperty("title") String title,
+            @JsonProperty("notice") String notice,
+            @JsonProperty("managerId") Long managerId,
+            @JsonProperty("categoryId") Long categoryId,
+            @JsonProperty("maximumCapacity") int maximumCapacity,
+            @JsonProperty("currentAttendance") int currentAttendance,
+            @JsonProperty("createdTime") String createdTime,
+            @JsonProperty("openChat") OpenChat openChat,
+            @JsonProperty("openChatRoomUserIds") List<Long> openChatRoomUserIds) {
+        this.id = id;
+        this.title = title;
+        this.notice = notice;
+        this.managerId = managerId;
+        this.categoryId = categoryId;
+        this.maximumCapacity = maximumCapacity;
+        this.currentAttendance = currentAttendance;
+        this.createdTime = createdTime;
+        this.openChat = openChat;
+        this.openChatRoomUserIds = openChatRoomUserIds;
+    }
+
+    public void setOpenChat(OpenChat openChat) {
+        this.openChat = openChat;
+    }
+
+    public void setOpenChatRoomUserIds(List<Long> openChatRoomUserIds) {
+        this.openChatRoomUserIds = openChatRoomUserIds;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacade.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacade.java
@@ -1,0 +1,9 @@
+package com.jongho.openChatRoom.application.facade;
+
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
+
+import java.util.List;
+
+public interface WebSocketOpenChatRoomFacade {
+    public List<OpenChatRoomDto> joinOpenChatRoomList(Long userId);
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacade.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacade.java
@@ -5,5 +5,5 @@ import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import java.util.List;
 
 public interface WebSocketOpenChatRoomFacade {
-    public List<OpenChatRoomDto> joinOpenChatRoomList(Long userId);
+    public List<OpenChatRoomDto> getOpenChatRoomList(Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
@@ -14,6 +14,9 @@ import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
 import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -29,6 +32,8 @@ public class WebSocketOpenChatRoomFacadeImpl implements WebSocketOpenChatRoomFac
     private final OpenChatService openChatService;
     private final OpenChatRedisService openChatRedisService;
     private final OpenChatRoomUserService openChatRoomUserService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
     public List<OpenChatRoomDto> joinOpenChatRoomList(Long userId){
         List<Long> openChatRoomIdList = openChatRoomRedisService.getOpenChatRoomIdList(userId);
         List<OpenChatRoomDto> openChatRoomDtoList;

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
@@ -176,7 +176,7 @@ public class WebSocketOpenChatRoomFacadeImpl implements WebSocketOpenChatRoomFac
             }
         }
 
-        count += openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(openChatRoomDto.getId(), lastExitTime);
+        count += openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(openChatRoomDto.getId(), lastExitTime, maxCount - count);
 
         return count;
     }

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -166,7 +167,7 @@ public class WebSocketOpenChatRoomFacadeImpl implements WebSocketOpenChatRoomFac
         int count = 0;
         int maxCount = 200;
         List<OpenChat> openChatList = openChatRedisService.getOpenChatListByOpenChatRoomId(openChatRoomDto.getId());
-        LocalDate lastExitDate = DateUtil.convertStringToDate(lastExitTime);
+        LocalDateTime lastExitDate = DateUtil.convertStringToDate(lastExitTime);
         for (OpenChat openChat : openChatList){
             if (DateUtil.convertStringToDate(openChat.getCreatedTime()).isAfter(lastExitDate)){
                 count++;

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
@@ -70,13 +70,14 @@ public class WebSocketOpenChatRoomFacadeImpl implements WebSocketOpenChatRoomFac
     private List<OpenChatRoomDto> enrichOpenChatRoomDtoListWithLastOpenChat(Long userId, List<RedisOpenChatRoom> openChatRoomList) {
         return openChatRoomList
                 .stream()
-                .map(OpenChatRoomDto::new)
-                .peek(openChatRoomDto -> {
+                .map(redisOpenChatRoom->{
+                    OpenChatRoomDto openChatRoomDto = new OpenChatRoomDto(redisOpenChatRoom);
                     openChatRoomDto.setOpenChat(getLastOpenChatByOpenChatRoomId(openChatRoomDto));
                     openChatRoomDto.setRedisOpenChatRoomConnectionInfo(getRedisOpenChatRoomConnectionInfo(userId, openChatRoomDto));
+
+                    return openChatRoomDto;
                 })
                 .toList();
-
     }
 
     /**

--- a/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/facade/WebSocketOpenChatRoomFacadeImpl.java
@@ -1,0 +1,150 @@
+package com.jongho.openChatRoom.application.facade;
+
+import com.jongho.common.exception.OpenChatRoomNotFoundException;
+import com.jongho.common.util.date.DateUtil;
+import com.jongho.openChat.application.service.OpenChatRedisService;
+import com.jongho.openChat.application.service.OpenChatService;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
+import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
+import com.jongho.openChatRoom.application.service.OpenChatRoomService;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WebSocketOpenChatRoomFacadeImpl implements WebSocketOpenChatRoomFacade{
+    private final OpenChatRoomRedisService openChatRoomRedisService;
+    private final OpenChatRoomService openChatRoomService;
+    private final OpenChatService openChatService;
+    private final OpenChatRedisService openChatRedisService;
+    private final OpenChatRoomUserService openChatRoomUserService;
+    public List<OpenChatRoomDto> joinOpenChatRoomList(Long userId){
+        List<Long> openChatRoomIdList = openChatRoomRedisService.getOpenChatRoomIdList(userId);
+        List<OpenChatRoomDto> openChatRoomDtoList;
+        if (openChatRoomIdList.size() == 0){
+            List<RedisOpenChatRoom> openChatRoomList = openChatRoomService.getJoinOpenChatRoomList(userId);
+            openChatRoomDtoList = enrichOpenChatRoomDtoListWithLastOpenChat(userId, openChatRoomList);
+        }else{
+            List<RedisOpenChatRoom> openChatRoomList = new ArrayList<>();
+            for (Long openChatRoomId : openChatRoomIdList){
+                RedisOpenChatRoom redisOpenChatRoom = getRedisOpenChatRoom(openChatRoomId);
+                if (redisOpenChatRoom == null){
+                    continue;
+                }
+                openChatRoomList.add(redisOpenChatRoom);
+            }
+            openChatRoomDtoList = enrichOpenChatRoomDtoListWithLastOpenChat(userId, openChatRoomList);
+        }
+
+        return sortOpenChatRoomDtoListByLastOpenChatCreatedTime(openChatRoomDtoList);
+    }
+
+    private List<OpenChatRoomDto> enrichOpenChatRoomDtoListWithLastOpenChat(Long userId, List<RedisOpenChatRoom> openChatRoomList) {
+        return openChatRoomList
+                .stream()
+                .map(OpenChatRoomDto::new)
+                .peek(openChatRoomDto -> {
+                    openChatRoomDto.setOpenChat(getLastOpenChatByOpenChatRoomId(openChatRoomDto));
+                    openChatRoomDto.setRedisOpenChatRoomConnectionInfo(getRedisOpenChatRoomConnectionInfo(userId, openChatRoomDto));
+                })
+                .toList();
+
+    }
+
+    public RedisOpenChatRoom getRedisOpenChatRoom(Long openChatRoomId){
+        Optional<RedisOpenChatRoom> redisOpenChatRoom = openChatRoomRedisService.getOpenChatRoom(openChatRoomId);
+        if (redisOpenChatRoom.isEmpty()){
+            Optional<RedisOpenChatRoom> openChatRoom = openChatRoomService.getRedisOpenChatRoomById(openChatRoomId);
+            if(openChatRoom.isEmpty()){
+                System.out.println("존재하지 않는 채팅방 id:" + openChatRoomId);
+                return null;
+            }
+            redisOpenChatRoom = openChatRoom;
+        }
+
+        return redisOpenChatRoom.get();
+    }
+
+    private OpenChat getLastOpenChatByOpenChatRoomId(OpenChatRoomDto openChatRoomDto){
+        Optional<OpenChat> openChat = openChatRedisService.getLastOpenChatByOpenChatRoomId(openChatRoomDto.getId());
+        if(openChat.isEmpty()){
+            OpenChat lastOpenChat = openChatService.getLastOpenChatByOpenChatRoomId(openChatRoomDto.getId())
+                    .orElse(null);
+            if(lastOpenChat != null){
+                openChatRoomRedisService.createOpenChatRoomLastMessage(openChatRoomDto.getId(), lastOpenChat);
+            }
+
+            return lastOpenChat;
+        }
+
+        return openChat.get();
+    }
+
+    private List<Long> getOpenChatRoomUserList(RedisOpenChatRoom openChatRoom){
+        List<Long> idList = openChatRoomRedisService.getOpenChatRoomIdList(openChatRoom.getId());
+        if (idList.size() == 0 || idList.size() != openChatRoom.getCurrentAttendance()){
+            idList = openChatRoomService.getOpenChatRoomUserList(openChatRoom.getId());
+            openChatRoomRedisService.createOpenChatRoomUserList(openChatRoom.getId(), idList);
+        }
+
+        return idList;
+    }
+
+    private RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, OpenChatRoomDto openChatRoomDto){
+        RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo = openChatRoomRedisService.getRedisOpenChatRoomConnectionInfo(userId, openChatRoomDto.getId());
+        if(redisOpenChatRoomConnectionInfo == null){
+            redisOpenChatRoomConnectionInfo = new RedisOpenChatRoomConnectionInfo();
+            OpenChatRoomUser openChatRoomUser = openChatRoomUserService.getOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomDto.getId(), userId)
+                    .orElseThrow(() -> new OpenChatRoomNotFoundException("채팅방에 참여하지 않은 유저입니다."));
+
+            redisOpenChatRoomConnectionInfo.setLastExitTime(openChatRoomUser.getLastExitTime());
+            redisOpenChatRoomConnectionInfo.setActive(0);
+            redisOpenChatRoomConnectionInfo.setUnReadMessageCount(getUnReadMessageCount(openChatRoomDto, openChatRoomUser.getLastExitTime()));
+
+            openChatRoomRedisService.createRedisOpenChatRoomConnectionInfo(userId, openChatRoomDto.getId(), redisOpenChatRoomConnectionInfo);
+        }
+
+        return redisOpenChatRoomConnectionInfo;
+    }
+
+    private int getUnReadMessageCount(OpenChatRoomDto openChatRoomDto, String lastExitTime){
+        int count = 0;
+        int maxCount = 200;
+        List<OpenChat> openChatList = openChatRedisService.getOpenChatListByOpenChatRoomId(openChatRoomDto.getId());
+        LocalDate lastExitDate = DateUtil.convertStringToDate(lastExitTime);
+        for (OpenChat openChat : openChatList){
+            if (DateUtil.convertStringToDate(openChat.getCreatedTime()).isAfter(lastExitDate)){
+                count++;
+            } else if(DateUtil.convertStringToDate(openChat.getCreatedTime()).isBefore(lastExitDate) || count >= maxCount){
+                return count;
+            }
+        }
+
+        count += openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(openChatRoomDto.getId(), lastExitTime);
+
+        return count;
+    }
+
+    private List<OpenChatRoomDto> sortOpenChatRoomDtoListByLastOpenChatCreatedTime(List<OpenChatRoomDto> myOpenChatRoomDtoList) {
+        return myOpenChatRoomDtoList.stream()
+                .sorted(
+                        Comparator.comparing(
+                                openChatRoomDto -> {
+                                    OpenChat openChat = openChatRoomDto.getLastChat();
+                                    return openChat != null ? openChat.getCreatedTime() : openChatRoomDto.getCreatedTime();
+                                },
+                                Comparator.reverseOrder()))
+                .toList();
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -1,0 +1,7 @@
+package com.jongho.openChatRoom.application.service;
+
+import java.util.List;
+
+public interface OpenChatRoomRedisService {
+    public List<Long> getOpenChatRoomIdList(Long userId);
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -1,7 +1,20 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface OpenChatRoomRedisService {
     public List<Long> getOpenChatRoomIdList(Long userId);
+    public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList);
+    public void createOpenChatRoomUserList(Long openChatRoomId, Long userId);
+    public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat);
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo);
+    public Optional<OpenChat> getLastOpenChatByChatRoomId(Long openChatRoomId);
+    public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
+    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
+    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -1,8 +1,8 @@
 package com.jongho.openChatRoom.application.service;
 
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,9 +12,9 @@ public interface OpenChatRoomRedisService {
     public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList);
     public void createOpenChatRoomUserList(Long openChatRoomId, Long userId);
     public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat);
-    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo);
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo);
     public Optional<OpenChat> getLastOpenChatByChatRoomId(Long openChatRoomId);
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
-    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
-    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
+    public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
+    public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -1,10 +1,14 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,4 +18,36 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
     public List<Long> getOpenChatRoomIdList(Long userId) {
         return openChatRoomRedisRepository.getOpenChatRoomIdList(userId);
     }
+    @Override
+    public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList) {
+        openChatRoomRedisRepository.createOpenChatRoomUserList(openChatRoomId, userIdList);
+    }
+    @Override
+    public void createOpenChatRoomUserList(Long openChatRoomId, Long userId) {
+        openChatRoomRedisRepository.createOpenChatRoomUserList(openChatRoomId, userId);
+    }
+    @Override
+    public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat) {
+        openChatRoomRedisRepository.createOpenChatRoomLastMessage(openChatRoomId, openChat);
+    }
+    @Override
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
+        openChatRoomRedisRepository.createRedisOpenChatRoomConnectionInfo(userId, openChatRoomId, redisOpenChatRoomConnectionInfo);
+    }
+    @Override
+    public List<Long> getOpenChatRoomUserList(Long openChatRoomId) {
+        return openChatRoomRedisRepository.getOpenChatRoomUserList(openChatRoomId);
+    }
+    @Override
+    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
+        return openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo(userId, openChatRoomId);
+    }
+    @Override
+    public Optional<OpenChat> getLastOpenChatByChatRoomId(Long chatRoomId){
+        return openChatRoomRedisRepository.getLastOpenChatByChatRoomId(chatRoomId);
+    };
+    @Override
+    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
+        return openChatRoomRedisRepository.getOpenChatRoom(openChatRoomId);
+    };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -1,0 +1,17 @@
+package com.jongho.openChatRoom.application.service;
+
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
+    private final OpenChatRoomRedisRepository openChatRoomRedisRepository;
+    @Override
+    public List<Long> getOpenChatRoomIdList(Long userId) {
+        return openChatRoomRedisRepository.getOpenChatRoomIdList(userId);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -1,8 +1,8 @@
 package com.jongho.openChatRoom.application.service;
 
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,15 +31,15 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
         openChatRoomRedisRepository.createOpenChatRoomLastMessage(openChatRoomId, openChat);
     }
     @Override
-    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
-        openChatRoomRedisRepository.createRedisOpenChatRoomConnectionInfo(userId, openChatRoomId, redisOpenChatRoomConnectionInfo);
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo) {
+        openChatRoomRedisRepository.createRedisOpenChatRoomConnectionInfo(userId, openChatRoomId, cachedOpenChatRoomConnectionInfo);
     }
     @Override
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId) {
         return openChatRoomRedisRepository.getOpenChatRoomUserList(openChatRoomId);
     }
     @Override
-    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
+    public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
         return openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo(userId, openChatRoomId);
     }
     @Override
@@ -47,7 +47,7 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
         return openChatRoomRedisRepository.getLastOpenChatByChatRoomId(chatRoomId);
     };
     @Override
-    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
+    public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
         return openChatRoomRedisRepository.getOpenChatRoom(openChatRoomId);
     };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -1,8 +1,7 @@
 package com.jongho.openChatRoom.application.service;
 
-import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,8 +14,8 @@ public interface OpenChatRoomService {
     public Optional<OpenChatRoom> getOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long userId,Long openChatRoomId, String notice);
-    public List<RedisOpenChatRoom> getJoinOpenChatRoomList(Long userId);
+    public List<CachedOpenChatRoom> getJoinOpenChatRoomList(Long userId);
     public List<Long> getOpenChatRoomUserList(Long OpenChatRoomId);
-    public Optional<RedisOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId);
+    public Optional<CachedOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId);
 
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -15,4 +15,5 @@ public interface OpenChatRoomService {
     public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long userId,Long openChatRoomId, String notice);
     public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId);
+    public List<Long> getOpenChatRoomUserList(Long OpenChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -2,6 +2,7 @@ package com.jongho.openChatRoom.application.service;
 
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,8 @@ public interface OpenChatRoomService {
     public Optional<OpenChatRoom> getOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long userId,Long openChatRoomId, String notice);
-    public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId);
+    public List<RedisOpenChatRoom> getJoinOpenChatRoomList(Long userId);
     public List<Long> getOpenChatRoomUserList(Long OpenChatRoomId);
+    public Optional<RedisOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId);
+
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomService.java
@@ -1,7 +1,9 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRoomService {
@@ -12,5 +14,5 @@ public interface OpenChatRoomService {
     public Optional<OpenChatRoom> getOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> getOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long userId,Long openChatRoomId, String notice);
-
+    public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -2,11 +2,13 @@ package com.jongho.openChatRoom.application.service;
 
 import com.jongho.common.exception.OpenChatRoomNotFoundException;
 import com.jongho.common.exception.UnAuthorizedException;
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -44,5 +46,9 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
             throw new UnAuthorizedException("채팅방 공지 수정 권한이 없습니다.");
         }
         openChatRoomRepository.updateOpenChatRoomNotice(openChatRoomId, notice);
+    }
+    @Override
+    public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId) {
+        return openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -4,6 +4,7 @@ import com.jongho.common.exception.OpenChatRoomNotFoundException;
 import com.jongho.common.exception.UnAuthorizedException;
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,11 +49,15 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
         openChatRoomRepository.updateOpenChatRoomNotice(openChatRoomId, notice);
     }
     @Override
-    public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId) {
+    public List<RedisOpenChatRoom> getJoinOpenChatRoomList(Long userId) {
         return openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId);
     }
     @Override
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId) {
         return openChatRoomRepository.selectOpenChatRoomUser(openChatRoomId);
+    }
+    @Override
+    public Optional<RedisOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId) {
+        return openChatRoomRepository.selectRedisOpenChatRoomById(openChatRoomId);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -51,4 +51,8 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
     public List<OpenChatRoomDto> getJoinOpenChatRoomList(Long userId) {
         return openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId);
     }
+    @Override
+    public List<Long> getOpenChatRoomUserList(Long openChatRoomId) {
+        return openChatRoomRepository.selectOpenChatRoomUser(openChatRoomId);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImpl.java
@@ -2,9 +2,8 @@ package com.jongho.openChatRoom.application.service;
 
 import com.jongho.common.exception.OpenChatRoomNotFoundException;
 import com.jongho.common.exception.UnAuthorizedException;
-import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,7 +48,7 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
         openChatRoomRepository.updateOpenChatRoomNotice(openChatRoomId, notice);
     }
     @Override
-    public List<RedisOpenChatRoom> getJoinOpenChatRoomList(Long userId) {
+    public List<CachedOpenChatRoom> getJoinOpenChatRoomList(Long userId) {
         return openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId);
     }
     @Override
@@ -57,7 +56,7 @@ public class OpenChatRoomServiceImpl implements OpenChatRoomService{
         return openChatRoomRepository.selectOpenChatRoomUser(openChatRoomId);
     }
     @Override
-    public Optional<RedisOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId) {
+    public Optional<CachedOpenChatRoom> getRedisOpenChatRoomById(Long openChatRoomId) {
         return openChatRoomRepository.selectRedisOpenChatRoomById(openChatRoomId);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -17,4 +17,5 @@ public interface OpenChatRoomMapper {
     public void updateOpenChatRoomNotice(@Param("id") Long id, @Param("notice") String notice);
     public OpenChatRoom selectOneOpenChatRoomByManagerIdAndTitle(@Param("managerId") Long managerId, @Param("title") String title);
     public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -2,10 +2,12 @@ package com.jongho.openChatRoom.dao.mapper;
 
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface OpenChatRoomMapper {
@@ -16,6 +18,7 @@ public interface OpenChatRoomMapper {
     public OpenChatRoom selectOneOpenChatRoomById(@Param("id") Long id);
     public void updateOpenChatRoomNotice(@Param("id") Long id, @Param("notice") String notice);
     public OpenChatRoom selectOneOpenChatRoomByManagerIdAndTitle(@Param("managerId") Long managerId, @Param("title") String title);
-    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
     public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
+    public RedisOpenChatRoom selectRedisOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -1,8 +1,11 @@
 package com.jongho.openChatRoom.dao.mapper;
 
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface OpenChatRoomMapper {
@@ -13,4 +16,5 @@ public interface OpenChatRoomMapper {
     public OpenChatRoom selectOneOpenChatRoomById(@Param("id") Long id);
     public void updateOpenChatRoomNotice(@Param("id") Long id, @Param("notice") String notice);
     public OpenChatRoom selectOneOpenChatRoomByManagerIdAndTitle(@Param("managerId") Long managerId, @Param("title") String title);
+    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapper.java
@@ -1,13 +1,11 @@
 package com.jongho.openChatRoom.dao.mapper;
 
-import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 @Mapper
 public interface OpenChatRoomMapper {
@@ -18,7 +16,7 @@ public interface OpenChatRoomMapper {
     public OpenChatRoom selectOneOpenChatRoomById(@Param("id") Long id);
     public void updateOpenChatRoomNotice(@Param("id") Long id, @Param("notice") String notice);
     public OpenChatRoom selectOneOpenChatRoomByManagerIdAndTitle(@Param("managerId") Long managerId, @Param("title") String title);
-    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<CachedOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
     public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
-    public RedisOpenChatRoom selectRedisOpenChatRoomById(Long openChatRoomId);
+    public CachedOpenChatRoom selectRedisOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -1,9 +1,8 @@
 package com.jongho.openChatRoom.dao.repository;
 
-import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -44,7 +43,7 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
         openChatRoomMapper.updateOpenChatRoomNotice(openChatRoomId, notice);
     }
     @Override
-    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId){
+    public List<CachedOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId){
         return openChatRoomMapper.selectJoinOpenChatRoomByUserId(userId);
     };
     @Override
@@ -52,7 +51,7 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
         return openChatRoomMapper.selectOpenChatRoomUser(openChatRoomId);
     };
     @Override
-    public Optional<RedisOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId){
+    public Optional<CachedOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId){
         return Optional.ofNullable(openChatRoomMapper.selectRedisOpenChatRoomById(openChatRoomId));
     };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.jongho.openChatRoom.dao.repository;
 
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -40,4 +42,8 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
     public void updateOpenChatRoomNotice(Long openChatRoomId, String notice) {
         openChatRoomMapper.updateOpenChatRoomNotice(openChatRoomId, notice);
     }
+    @Override
+    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId){
+        return openChatRoomMapper.selectJoinOpenChatRoomByUserId(userId);
+    };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.jongho.openChatRoom.dao.repository;
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.dao.mapper.OpenChatRoomMapper;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -43,11 +44,15 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
         openChatRoomMapper.updateOpenChatRoomNotice(openChatRoomId, notice);
     }
     @Override
-    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId){
+    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId){
         return openChatRoomMapper.selectJoinOpenChatRoomByUserId(userId);
     };
     @Override
     public List<Long> selectOpenChatRoomUser(Long openChatRoomId){
         return openChatRoomMapper.selectOpenChatRoomUser(openChatRoomId);
+    };
+    @Override
+    public Optional<RedisOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId){
+        return Optional.ofNullable(openChatRoomMapper.selectRedisOpenChatRoomById(openChatRoomId));
     };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomMybatisRepositoryImpl.java
@@ -46,4 +46,8 @@ public class OpenChatRoomMybatisRepositoryImpl implements OpenChatRoomRepository
     public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId){
         return openChatRoomMapper.selectJoinOpenChatRoomByUserId(userId);
     };
+    @Override
+    public List<Long> selectOpenChatRoomUser(Long openChatRoomId){
+        return openChatRoomMapper.selectOpenChatRoomUser(openChatRoomId);
+    };
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.jongho.openChatRoom.dao.repository;
+
+import com.jongho.common.util.redis.BaseRedisTemplate;
+import com.jongho.common.util.redis.RedisKeyGeneration;
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisRepository {
+    private final BaseRedisTemplate baseRedisTemplate;
+
+    @Override
+    public List<Long> getOpenChatRoomIdList(Long userId) {
+        return baseRedisTemplate.getAllListData(RedisKeyGeneration.getJoinedChatRoomsKey(userId), Long.class);
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -2,11 +2,15 @@ package com.jongho.openChatRoom.dao.repository;
 
 import com.jongho.common.util.redis.BaseRedisTemplate;
 import com.jongho.common.util.redis.RedisKeyGeneration;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -16,5 +20,47 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
     @Override
     public List<Long> getOpenChatRoomIdList(Long userId) {
         return baseRedisTemplate.getAllListData(RedisKeyGeneration.getJoinedChatRoomsKey(userId), Long.class);
+    }
+
+    @Override
+    public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList) {
+        baseRedisTemplate.setAllListData(RedisKeyGeneration.getChatRoomUserListKey(openChatRoomId), userIdList);
+    }
+
+    @Override
+    public void createOpenChatRoomUserList(Long openChatRoomId, Long userId) {
+        baseRedisTemplate.setListData(RedisKeyGeneration.getChatRoomUserListKey(openChatRoomId), userId);
+    }
+
+    @Override
+    public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat) {
+        baseRedisTemplate.setListData(RedisKeyGeneration.getLastMessageKey(openChatRoomId), openChat);
+    }
+
+    @Override
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
+        baseRedisTemplate.setHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), redisOpenChatRoomConnectionInfo.toMap());
+    }
+
+    @Override
+    public List<Long> getOpenChatRoomUserList(Long openChatRoomId) {
+        return baseRedisTemplate.getAllListData(RedisKeyGeneration.getChatRoomUserListKey(openChatRoomId), Long.class);
+    }
+
+    @Override
+    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
+        return baseRedisTemplate.getHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), RedisOpenChatRoomConnectionInfo.class);
+    }
+
+    @Override
+    public Optional<OpenChat> getLastOpenChatByChatRoomId(Long chatRoomId){
+        return Optional.ofNullable(
+                baseRedisTemplate.getData(RedisKeyGeneration.getLastMessageKey(chatRoomId), OpenChat.class));
+    }
+
+    @Override
+    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
+        return Optional.ofNullable(
+                baseRedisTemplate.getData(RedisKeyGeneration.getChatRoomKey(openChatRoomId), RedisOpenChatRoom.class));
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.jongho.openChatRoom.dao.repository;
 import com.jongho.common.util.redis.BaseRedisTemplate;
 import com.jongho.common.util.redis.RedisKeyGeneration;
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -38,8 +38,8 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
     }
 
     @Override
-    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo) {
-        baseRedisTemplate.setHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), redisOpenChatRoomConnectionInfo.toMap());
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo) {
+        baseRedisTemplate.setHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), cachedOpenChatRoomConnectionInfo.toMap());
     }
 
     @Override
@@ -48,8 +48,8 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
     }
 
     @Override
-    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
-        return baseRedisTemplate.getHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), RedisOpenChatRoomConnectionInfo.class);
+    public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
+        return baseRedisTemplate.getHashData(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), CachedOpenChatRoomConnectionInfo.class);
     }
 
     @Override
@@ -59,8 +59,8 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
     }
 
     @Override
-    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
+    public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
         return Optional.ofNullable(
-                baseRedisTemplate.getData(RedisKeyGeneration.getChatRoomKey(openChatRoomId), RedisOpenChatRoom.class));
+                baseRedisTemplate.getData(RedisKeyGeneration.getChatRoomKey(openChatRoomId), CachedOpenChatRoom.class));
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/CachedOpenChatRoom.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/CachedOpenChatRoom.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode(of = "id")
-public class RedisOpenChatRoom {
+public class CachedOpenChatRoom {
     private final Long id;
     private final String title;
     private final String notice;
@@ -20,7 +20,7 @@ public class RedisOpenChatRoom {
     private final String createdTime;
 
     @JsonCreator
-    public RedisOpenChatRoom(
+    public CachedOpenChatRoom(
             @JsonProperty("id") Long id,
             @JsonProperty("title") String title,
             @JsonProperty("notice") String notice,

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/CachedOpenChatRoomConnectionInfo.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/CachedOpenChatRoomConnectionInfo.java
@@ -14,13 +14,13 @@ import java.util.Map;
 @Setter
 @ToString
 @NoArgsConstructor
-public class RedisOpenChatRoomConnectionInfo {
+public class CachedOpenChatRoomConnectionInfo {
     private int active;
     private int unReadMessageCount;
     private String lastExitTime;
 
     @JsonCreator
-    public RedisOpenChatRoomConnectionInfo(
+    public CachedOpenChatRoomConnectionInfo(
             @JsonProperty("active") int active,
             @JsonProperty("unReadMessageCount") int unReadMessageCount,
             @JsonProperty("lastExitTime") String lastExitTime) {

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoom.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoom.java
@@ -1,0 +1,41 @@
+package com.jongho.openChatRoom.domain.model.redis;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode(of = "id")
+public class RedisOpenChatRoom {
+    private final Long id;
+    private final String title;
+    private final String notice;
+    private final Long managerId;
+    private final Long categoryId;
+    private final int maximumCapacity;
+    private final int currentAttendance;
+    private final String createdTime;
+
+    @JsonCreator
+    public RedisOpenChatRoom(
+            @JsonProperty("id") Long id,
+            @JsonProperty("title") String title,
+            @JsonProperty("notice") String notice,
+            @JsonProperty("managerId") Long managerId,
+            @JsonProperty("categoryId") Long categoryId,
+            @JsonProperty("maximumCapacity") int maximumCapacity,
+            @JsonProperty("currentAttendance") int currentAttendance,
+            @JsonProperty("createdTime") String createdTime) {
+        this.id = id;
+        this.title = title;
+        this.notice = notice;
+        this.managerId = managerId;
+        this.categoryId = categoryId;
+        this.maximumCapacity = maximumCapacity;
+        this.currentAttendance = currentAttendance;
+        this.createdTime = createdTime;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoomConnectionInfo.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoomConnectionInfo.java
@@ -1,4 +1,4 @@
-package com.jongho.openChatRoom.application.dto.response;
+package com.jongho.openChatRoom.domain.model.redis;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -9,13 +9,13 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-public class OpenChatRoomConnectionInfo {
+public class RedisOpenChatRoomConnectionInfo {
     private int active;
     private int unReadMessageCount;
     private int lastExitTime;
 
     @JsonCreator
-    public OpenChatRoomConnectionInfo(
+    public RedisOpenChatRoomConnectionInfo(
             @JsonProperty("active") int active,
             @JsonProperty("unReadMessageCount") int unReadMessageCount,
             @JsonProperty("lastExitTime") int lastExitTime) {

--- a/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoomConnectionInfo.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/model/redis/RedisOpenChatRoomConnectionInfo.java
@@ -3,24 +3,38 @@ package com.jongho.openChatRoom.domain.model.redis;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @Setter
 @ToString
+@NoArgsConstructor
 public class RedisOpenChatRoomConnectionInfo {
     private int active;
     private int unReadMessageCount;
-    private int lastExitTime;
+    private String lastExitTime;
 
     @JsonCreator
     public RedisOpenChatRoomConnectionInfo(
             @JsonProperty("active") int active,
             @JsonProperty("unReadMessageCount") int unReadMessageCount,
-            @JsonProperty("lastExitTime") int lastExitTime) {
+            @JsonProperty("lastExitTime") String lastExitTime) {
         this.active = active;
         this.unReadMessageCount = unReadMessageCount;
         this.lastExitTime = lastExitTime;
+    }
+
+    public Map<String, String> toMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("active", this.active+"");
+        map.put("unReadMessageCount", this.unReadMessageCount+"");
+        map.put("lastExitTime", this.lastExitTime+"");
+
+        return map;
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -1,8 +1,8 @@
 package com.jongho.openChatRoom.domain.repository;
 
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,9 +12,9 @@ public interface OpenChatRoomRedisRepository {
     public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList);
     public void createOpenChatRoomUserList(Long openChatRoomId, Long userId);
     public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat);
-    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo);
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo);
     public Optional<OpenChat> getLastOpenChatByChatRoomId(Long chatRoomId);
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
-    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
-    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
+    public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
+    public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -1,0 +1,7 @@
+package com.jongho.openChatRoom.domain.repository;
+
+import java.util.List;
+
+public interface OpenChatRoomRedisRepository {
+    public List<Long> getOpenChatRoomIdList(Long userId);
+}

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -1,7 +1,20 @@
 package com.jongho.openChatRoom.domain.repository;
 
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface OpenChatRoomRedisRepository {
     public List<Long> getOpenChatRoomIdList(Long userId);
+    public void createOpenChatRoomUserList(Long openChatRoomId, List<Long> userIdList);
+    public void createOpenChatRoomUserList(Long openChatRoomId, Long userId);
+    public void createOpenChatRoomLastMessage(Long openChatRoomId, OpenChat openChat);
+    public void createRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId, RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo);
+    public Optional<OpenChat> getLastOpenChatByChatRoomId(Long chatRoomId);
+    public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
+    public RedisOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
+    public Optional<RedisOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -15,4 +15,5 @@ public interface OpenChatRoomRepository {
     public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long openChatRoomId, String notice);
     public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -1,7 +1,9 @@
 package com.jongho.openChatRoom.domain.repository;
 
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OpenChatRoomRepository {
@@ -12,4 +14,5 @@ public interface OpenChatRoomRepository {
     public Optional<OpenChatRoom> selectOneOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long openChatRoomId, String notice);
+    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -1,8 +1,7 @@
 package com.jongho.openChatRoom.domain.repository;
 
-import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +14,7 @@ public interface OpenChatRoomRepository {
     public Optional<OpenChatRoom> selectOneOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long openChatRoomId, String notice);
-    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<CachedOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
     public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
-    public Optional<RedisOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId);
+    public Optional<CachedOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.jongho.openChatRoom.domain.repository;
 
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,7 @@ public interface OpenChatRoomRepository {
     public Optional<OpenChatRoom> selectOneOpenChatRoomByIdForUpdate(Long openChatRoomId);
     public Optional<OpenChatRoom> selectOneOpenChatRoomById(Long openChatRoomId);
     public void updateOpenChatRoomNotice(Long openChatRoomId, String notice);
-    public List<OpenChatRoomDto> selectJoinOpenChatRoomByUserId(Long userId);
+    public List<RedisOpenChatRoom> selectJoinOpenChatRoomByUserId(Long userId);
     public List<Long> selectOpenChatRoomUser(Long openChatRoomId);
+    public Optional<RedisOpenChatRoom> selectRedisOpenChatRoomById(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -1,0 +1,19 @@
+package com.jongho.openChatRoom.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -1,16 +1,26 @@
 package com.jongho.openChatRoom.handler;
 
+import com.jongho.common.util.websocket.BaseWebSocketMessage;
+import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
+import com.jongho.openChatRoom.application.facade.WebSocketOpenChatRoomFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
+    private final WebSocketOpenChatRoomFacade webSocketOpenChatRoomFacade;
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.joinOpenChatRoomList((long) session.getAttributes().get("userId"));
+
+        session.sendMessage(
+                new TextMessage(BaseWebSocketMessage.join(openChatRoomDto).toString()));
     }
 
     @Override

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -21,17 +21,26 @@ public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
     private final WebSocketOpenChatRoomFacade webSocketOpenChatRoomFacade;
     @Override
     public void afterConnectionEstablished(@NotNull WebSocketSession session){
-        try (session) {
+        try  {
             List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.getOpenChatRoomList((long) session.getAttributes().get("userId"));
 
             session.sendMessage(
                     new TextMessage(BaseWebSocketMessage.join(openChatRoomDto)));
         } catch (Exception e) {
-            log.error("WebSocketOpenChatRoomHandler.afterConnectionEstablished: " + e.getMessage());
+            log.error(e.getMessage());
+            handleWebSocketClose(session);
         }
     }
 
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    }
+
+    private void handleWebSocketClose(WebSocketSession session) {
+        try {
+            session.close();
+        } catch (IOException e) {
+            log.error("session.close");
+        }
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -25,7 +25,7 @@ public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
             List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.getOpenChatRoomList((long) session.getAttributes().get("userId"));
 
             session.sendMessage(
-                    new TextMessage(BaseWebSocketMessage.join(openChatRoomDto)));
+                    new TextMessage(BaseWebSocketMessage.of(openChatRoomDto)));
         } catch (Exception e) {
             log.error(e.getMessage());
             handleWebSocketClose(session);

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -20,7 +20,7 @@ public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
         List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.joinOpenChatRoomList((long) session.getAttributes().get("userId"));
 
         session.sendMessage(
-                new TextMessage(BaseWebSocketMessage.join(openChatRoomDto).toString()));
+                new TextMessage(BaseWebSocketMessage.join(openChatRoomDto)));
     }
 
     @Override

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -4,23 +4,31 @@ import com.jongho.common.util.websocket.BaseWebSocketMessage;
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.application.facade.WebSocketOpenChatRoomFacade;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
 import java.util.List;
 
 @Component
+@Log4j2
 @RequiredArgsConstructor
 public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
     private final WebSocketOpenChatRoomFacade webSocketOpenChatRoomFacade;
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.joinOpenChatRoomList((long) session.getAttributes().get("userId"));
+    public void afterConnectionEstablished(@NotNull WebSocketSession session){
+        try (session) {
+            List<OpenChatRoomDto> openChatRoomDto = webSocketOpenChatRoomFacade.getOpenChatRoomList((long) session.getAttributes().get("userId"));
 
-        session.sendMessage(
-                new TextMessage(BaseWebSocketMessage.join(openChatRoomDto)));
+            session.sendMessage(
+                    new TextMessage(BaseWebSocketMessage.join(openChatRoomDto)));
+        } catch (Exception e) {
+            log.error("WebSocketOpenChatRoomHandler.afterConnectionEstablished: " + e.getMessage());
+        }
     }
 
     @Override

--- a/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
+++ b/api/src/main/java/com/jongho/openChatRoomUser/domain/model/OpenChatRoomUser.java
@@ -5,8 +5,10 @@ import lombok.*;
 @Getter
 @Setter
 @RequiredArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 public class OpenChatRoomUser {
     private final Long openChatRoomId;
     private final Long userId;
+    private String LastExitTime;
 }

--- a/api/src/main/resources/log4j2.xml
+++ b/api/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/api/src/main/resources/mapper/openChatMapper.xml
+++ b/api/src/main/resources/mapper/openChatMapper.xml
@@ -16,4 +16,13 @@
         ORDER BY id DESC
         LIMIT 1
     </select>
+    <select id="selectUnReadOpenChatCountByChatRoomIdAndLastExitTime">
+        SELECT
+            COUNT(*) AS unread_message_count
+        FROM open_chats
+        WHERE open_chat_room_id = #{openChatRoomId}
+        AND created_time > #{lastExitTime}
+        AND is_deleted = 0
+        LIMIT 200
+    </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatMapper.xml
+++ b/api/src/main/resources/mapper/openChatMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "//mybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="com.jongho.openChat.dao.mapper.OpenChatMapper">
+    <select id="selectLastOpenChatByChatRoomId" resultType="com.jongho.openChat.domain.model.OpenChat">
+        SELECT
+            id,
+            sender_id,
+            open_chat_room_id,
+            message,
+            type,
+            is_deleted,
+            deleted_time,
+            created_time
+        FROM open_chats
+        WHERE open_chat_room_id = #{openChatRoomId}
+        ORDER BY id DESC
+        LIMIT 1
+    </select>
+</mapper>

--- a/api/src/main/resources/mapper/openChatMapper.xml
+++ b/api/src/main/resources/mapper/openChatMapper.xml
@@ -23,6 +23,6 @@
         WHERE open_chat_room_id = #{openChatRoomId}
         AND created_time > #{lastExitTime}
         AND is_deleted = 0
-        LIMIT 200
+        LIMIT #{limit}
     </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -73,4 +73,22 @@
         WHERE id = #{id}
         AND deleted_time is null
     </update>
+    <select id="selectJoinOpenChatRoomByUserId" parameterType="Long" resultType="com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomDto">
+        SELECT
+            open_chat_rooms.id,
+            open_chat_rooms.title,
+            open_chat_rooms.notice,
+            open_chat_rooms.manager_id,
+            open_chat_rooms.category_id,
+            open_chat_rooms.maximum_capacity,
+            open_chat_rooms.current_attendance,
+            open_chat_rooms.created_time
+        FROM open_chat_rooms
+        INNER JOIN open_chat_room_users
+            ON open_chat_rooms.id = open_chat_room_users.open_chat_room_id
+            AND open_chat_room_users.user_id = #{userId}
+            AND open_chat_room_users.deleted_time is null
+        WHERE open_chat_room_users.user_id = #{userId}
+            AND open_chat_rooms.deleted_time is null
+    </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -91,4 +91,14 @@
         WHERE open_chat_room_users.user_id = #{userId}
             AND open_chat_rooms.deleted_time is null
     </select>
+    <select id="selectOpenChatRoomUser" parameterType="Long">
+        SELECT
+            open_chat_room_users.user_id
+        FROM open_chat_rooms
+        INNER JOIN open_chat_room_users
+            ON open_chat_rooms.id = open_chat_room_users.open_chat_room_id
+            AND open_chat_room_users.deleted_time is null
+        WHERE open_chat_rooms.id = #{openChatRoomId}
+            AND open_chat_rooms.deleted_time is null
+    </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -73,7 +73,7 @@
         WHERE id = #{id}
         AND deleted_time is null
     </update>
-    <select id="selectJoinOpenChatRoomByUserId" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom">
+    <select id="selectJoinOpenChatRoomByUserId" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom">
         SELECT
             open_chat_rooms.id,
             open_chat_rooms.title,
@@ -101,7 +101,7 @@
         WHERE open_chat_rooms.id = #{openChatRoomId}
             AND open_chat_rooms.deleted_time is null
     </select>
-    <select id="selectRedisOpenChatRoomById" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom">
+    <select id="selectRedisOpenChatRoomById" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom">
         SELECT
             id,
             title,

--- a/api/src/main/resources/mapper/openChatRoomMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomMapper.xml
@@ -73,7 +73,7 @@
         WHERE id = #{id}
         AND deleted_time is null
     </update>
-    <select id="selectJoinOpenChatRoomByUserId" parameterType="Long" resultType="com.jongho.openChatRoom.application.dto.response.MyOpenChatRoomDto">
+    <select id="selectJoinOpenChatRoomByUserId" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom">
         SELECT
             open_chat_rooms.id,
             open_chat_rooms.title,
@@ -100,5 +100,20 @@
             AND open_chat_room_users.deleted_time is null
         WHERE open_chat_rooms.id = #{openChatRoomId}
             AND open_chat_rooms.deleted_time is null
+    </select>
+    <select id="selectRedisOpenChatRoomById" parameterType="Long" resultType="com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom">
+        SELECT
+            id,
+            title,
+            notice,
+            manager_id,
+            category_id,
+            maximum_capacity,
+            current_attendance,
+            created_time
+        FROM open_chat_rooms
+        WHERE id = #{openChatRoomId}
+        AND deleted_time is null
+        LIMIT 1
     </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatRoomUserMapper.xml
+++ b/api/src/main/resources/mapper/openChatRoomUserMapper.xml
@@ -6,7 +6,7 @@
         VALUES (#{openChatRoomId}, #{userId})
     </insert>
     <select id="selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId" parameterType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser" resultType="com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser">
-        SELECT open_chat_room_id, user_id
+        SELECT open_chat_room_id, user_id, last_exit_time
         FROM open_chat_room_users
         WHERE open_chat_room_id = #{openChatRoomId}
         AND user_id = #{userId}

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS open_chat_rooms (
 CREATE TABLE IF NOT EXISTS open_chat_room_users (
   user_id int NOT NULL COMMENT '유저 id',
   open_chat_room_id int NOT NULL COMMENT '오픈채팅방 id',
+  last_exit_time timestamp NOT NULL DEFAULT NOW() COMMENT '채팅방 나간 시간',
   is_deleted int NOT NULL DEFAULT 0 COMMENT '삭제 여부',
   deleted_time timestamp COMMENT '삭제 날짜',
   created_time timestamp NOT NULL DEFAULT NOW() COMMENT '생성 날짜',

--- a/api/src/test/java/com/jongho/openChat/application/service/OpenChatRedisServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChat/application/service/OpenChatRedisServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRedisServiceImpl 클래스")
+public class OpenChatRedisServiceImplTest {
+    @Mock
+    private OpenChatRedisRepository openChatRedisRepository;
+    @InjectMocks
+    private OpenChatRedisServiceImpl openChatRedisService;
+    @Nested
+    @DisplayName("getLastOpenChatByOpenChatRoomId 메소드는")
+    class Describe_getLastOpenChatByOpenChatRoomId {
+        @Test
+        @DisplayName("openChatRedisRepository.selectLastOpenChatByChatRoomId 메소드를 호출하고 받은 반환값을 반환한다.")
+        void openChatRedisRepository_selectLastOpenChatByChatRoomId_메소드를_호출하고_받은_반환값을_반환한다() {
+            // given
+            Optional<OpenChat> openChat = Optional.of(new OpenChat(
+                    1L,
+                    1L,
+                    1L,
+                    "test",
+                    1,
+                    0,
+                    null,
+                    "2024-01-29 00:00:00"
+            ));
+            when(openChatRedisRepository.selectLastOpenChatByChatRoomId(1L)).thenReturn(openChat);
+
+            // when
+            Optional<OpenChat> result = openChatRedisService.getLastOpenChatByOpenChatRoomId(1L);
+
+            // then
+            verify(openChatRedisRepository).selectLastOpenChatByChatRoomId(1L);
+            assertEquals(openChat, result);
+        }
+        @Nested
+        @DisplayName("getOpenChatListByOpenChatRoomId 메소드는")
+        class Describe_getOpenChatListByOpenChatRoomId {
+            @Test
+            @DisplayName("openChatRedisRepository.selectOpenChatListByChatRoomId 메소드를 호출하고 받은 반환값을 반환한다.")
+            void openChatRedisRepository_selectOpenChatListByChatRoomId_메소드를_호출하고_받은_반환값을_반환한다() {
+                // given
+                List<OpenChat> openChatList = List.of(new OpenChat(
+                        1L,
+                        1L,
+                        1L,
+                        "test",
+                        1,
+                        0,
+                        null,
+                        "2024-01-29 00:00:00"
+                ));
+                when(openChatRedisRepository.selectOpenChatListByChatRoomId(1L)).thenReturn(openChatList);
+
+                // when
+                List<OpenChat> result = openChatRedisService.getOpenChatListByOpenChatRoomId(1L);
+
+                // then
+                verify(openChatRedisRepository).selectOpenChatListByChatRoomId(1L);
+                assertEquals(1, result.size());
+            }
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChat/application/service/OpenChatServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChat/application/service/OpenChatServiceImplTest.java
@@ -61,13 +61,14 @@ public class OpenChatServiceImplTest {
             Long chatRoomId = 1L;
             String lastExitTime = "2024-01-29 00:00:00";
             int unReadOpenChatCount = 1;
-            when(openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime)).thenReturn(unReadOpenChatCount);
+            int limit = 150;
+            when(openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime, limit)).thenReturn(unReadOpenChatCount);
 
             // when
-            int result = openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(chatRoomId, lastExitTime);
+            int result = openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(chatRoomId, lastExitTime, limit);
 
             // then
-            verify(openChatRepository).selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime);
+            verify(openChatRepository).selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime, limit);
             assertEquals(unReadOpenChatCount, result);
         }
     }

--- a/api/src/test/java/com/jongho/openChat/application/service/OpenChatServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChat/application/service/OpenChatServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.jongho.openChat.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChat.domain.repository.OpenChatRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRedisServiceImpl 클래스")
+public class OpenChatServiceImplTest {
+    @Mock
+    private OpenChatRepository openChatRepository;
+    @InjectMocks
+    private OpenChatServiceImpl openChatService;
+    @Nested
+    @DisplayName("getLastOpenChatByOpenChatRoomId 메서드는")
+    class Describe_getLastOpenChatByOpenChatRoomId{
+        @Test
+        @DisplayName("openChatRepository.selectLastOpenChatByChatRoomId 메서드를 호출하고 반환받은 값을 반환한다.")
+        void openChatRepository_selectLastOpenChatByChatRoomId_메서드를_호출하고_반환받은_값을_반환한다(){
+            // given
+            Long chatRoomId = 1L;
+            Optional<OpenChat> openChat = Optional.of(new OpenChat(
+                    1L,
+                    1L,
+                    1L,
+                    "test",
+                    1,
+                    0,
+                    null,
+                    "2024-01-29 00:00:00"
+            ));
+            when(openChatRepository.selectLastOpenChatByChatRoomId(chatRoomId)).thenReturn(openChat);
+
+            // when
+            Optional<OpenChat> result = openChatService.getLastOpenChatByOpenChatRoomId(chatRoomId);
+
+            // then
+            verify(openChatRepository).selectLastOpenChatByChatRoomId(chatRoomId);
+            assertEquals(openChat, result);
+        }
+    }
+    @Nested
+    @DisplayName("getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime 메서드는")
+    class Describe_getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime{
+        @Test
+        @DisplayName("openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime 메서드를 호출하고 반환받은 값을 반환한다.")
+        void openChatRepository_selectUnReadOpenChatCountByChatRoomIdAndLastExitTime_메서드를_호출하고_반환받은_값을_반환한다(){
+            // given
+            Long chatRoomId = 1L;
+            String lastExitTime = "2024-01-29 00:00:00";
+            int unReadOpenChatCount = 1;
+            when(openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime)).thenReturn(unReadOpenChatCount);
+
+            // when
+            int result = openChatService.getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(chatRoomId, lastExitTime);
+
+            // then
+            verify(openChatRepository).selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(chatRoomId, lastExitTime);
+            assertEquals(unReadOpenChatCount, result);
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
@@ -1,0 +1,182 @@
+package com.jongho.openChatRoom.application.service;
+
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OpenChatRoomRedisServiceImpl 클래스")
+public class OpenChatRoomRedisServiceImplTest {
+    @Mock
+    private OpenChatRoomRedisRepository openChatRoomRedisRepository;
+    @InjectMocks
+    private OpenChatRoomRedisServiceImpl openChatRoomRedisService;
+    @Nested
+    @DisplayName("getOpenChatRoomIdList 메서드는")
+    class Describe_getOpenChatRoomIdList{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.getOpenChatRoomIdList 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_getOpenChatRoomIdList_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            List<Long> openChatRoomIdList = List.of(1L, 2L, 3L);
+            when(openChatRoomRedisRepository.getOpenChatRoomIdList(1L)).thenReturn(openChatRoomIdList);
+
+            // when
+            openChatRoomRedisService.getOpenChatRoomIdList(1L);
+
+            // then
+            verify(openChatRoomRedisRepository).getOpenChatRoomIdList(1L);
+        }
+    }
+    @Nested
+    @DisplayName("createOpenChatRoomUserList 메서드는")
+    class Describe_createOpenChatRoomUserList{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.createOpenChatRoomUserList 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_createOpenChatRoomUserList_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            List<Long> userIdList = List.of(1L, 2L, 3L);
+
+            // when
+            openChatRoomRedisService.createOpenChatRoomUserList(1L, userIdList);
+
+            // then
+            verify(openChatRoomRedisRepository).createOpenChatRoomUserList(1L, userIdList);
+        }
+    }
+    @Nested
+    @DisplayName("createOpenChatRoomLastMessage 메서드는")
+    class Describe_createOpenChatRoomLastMessage{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.createOpenChatRoomLastMessage 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_createOpenChatRoomLastMessage_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+
+            // when
+            openChatRoomRedisService.createOpenChatRoomLastMessage(1L, null);
+
+            // then
+            verify(openChatRoomRedisRepository).createOpenChatRoomLastMessage(1L, null);
+        }
+    }
+    @Nested
+    @DisplayName("createRedisOpenChatRoomConnectionInfo 메서드는")
+    class Describe_createRedisOpenChatRoomConnectionInfo{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.createRedisOpenChatRoomConnectionInfo 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_createRedisOpenChatRoomConnectionInfo_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo = new RedisOpenChatRoomConnectionInfo();
+            // when
+            openChatRoomRedisService.createRedisOpenChatRoomConnectionInfo(1L, 1L, redisOpenChatRoomConnectionInfo);
+
+            // then
+            verify(openChatRoomRedisRepository).createRedisOpenChatRoomConnectionInfo(1L, 1L, redisOpenChatRoomConnectionInfo);
+        }
+    }
+    @Nested
+    @DisplayName("getOpenChatRoomUserList 메서드는")
+    class Describe_getOpenChatRoomUserList{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.getOpenChatRoomUserList 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_getOpenChatRoomUserList_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            List<Long> userIdList = List.of(1L, 2L, 3L);
+            when(openChatRoomRedisRepository.getOpenChatRoomUserList(1L)).thenReturn(userIdList);
+
+            // when
+            List<Long> result = openChatRoomRedisService.getOpenChatRoomUserList(1L);
+
+            // then
+            verify(openChatRoomRedisRepository).getOpenChatRoomUserList(1L);
+            assertEquals(userIdList, result);
+        }
+    }
+    @Nested
+    @DisplayName("getRedisOpenChatRoomConnectionInfo 메서드는")
+    class Describe_getRedisOpenChatRoomConnectionInfo{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_getRedisOpenChatRoomConnectionInfo_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo = new RedisOpenChatRoomConnectionInfo();
+            when(openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo(1L, 1L)).thenReturn(redisOpenChatRoomConnectionInfo);
+
+            // when
+            RedisOpenChatRoomConnectionInfo result = openChatRoomRedisService.getRedisOpenChatRoomConnectionInfo(1L, 1L);
+
+            // then
+            verify(openChatRoomRedisRepository).getRedisOpenChatRoomConnectionInfo(1L, 1L);
+            assertEquals(redisOpenChatRoomConnectionInfo, result);
+        }
+    }
+    @Nested
+    @DisplayName("getLastOpenChatByChatRoomId 메서드는")
+    class Describe_getLastOpenChatByChatRoomId{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.getLastOpenChatByChatRoomId 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_getLastOpenChatByChatRoomId_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            Optional<OpenChat> openChat = Optional.of(new OpenChat(
+                    1L,
+                    1L,
+                    1L,
+                    "test",
+                    1,
+                    0,
+                    null,
+                    "2024-01-29 00:00:00"
+            ));
+            when(openChatRoomRedisRepository.getLastOpenChatByChatRoomId(1L)).thenReturn(openChat);
+
+            // when
+            Optional<OpenChat> result =openChatRoomRedisService.getLastOpenChatByChatRoomId(1L);
+
+            // then
+            verify(openChatRoomRedisRepository).getLastOpenChatByChatRoomId(1L);
+            assertEquals(openChat, result);
+        }
+    }
+    @Nested
+    @DisplayName("getOpenChatRoom 메서드는")
+    class Describe_getOpenChatRoom{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.getOpenChatRoom 메서드를 호출한다.")
+        void openChatRoomRedisRepositoryd_getOpenChatRoom_메서드를_호출하고_받은_값을_반환한다(){
+            // given
+            Optional<RedisOpenChatRoom> redisOpenChatRoom  = Optional.of(new RedisOpenChatRoom(
+                    1L,
+                    "title",
+                    "notice",
+                    1L,
+                    1L,
+                    200,
+                    3,
+                    "2024-01-29 00:00:00"
+            ));
+            when(openChatRoomRedisRepository.getOpenChatRoom(1L)).thenReturn(redisOpenChatRoom);
+
+            // when
+            Optional<RedisOpenChatRoom> result = openChatRoomRedisService.getOpenChatRoom(1L);
+
+            // then
+            verify(openChatRoomRedisRepository).getOpenChatRoom(1L);
+            assertEquals(redisOpenChatRoom, result);
+        }
+    }
+}

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
@@ -1,8 +1,8 @@
 package com.jongho.openChatRoom.application.service;
 
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoomConnectionInfo;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRedisRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -76,17 +76,17 @@ public class OpenChatRoomRedisServiceImplTest {
     }
     @Nested
     @DisplayName("createRedisOpenChatRoomConnectionInfo 메서드는")
-    class Describe_createRedisOpenChatRoomConnectionInfo{
+    class Describe_createCachedOpenChatRoomConnectionInfo {
         @Test
         @DisplayName("openChatRoomRedisRepository.createRedisOpenChatRoomConnectionInfo 메서드를 호출한다.")
         void openChatRoomRedisRepositoryd_createRedisOpenChatRoomConnectionInfo_메서드를_호출하고_받은_값을_반환한다(){
             // given
-            RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo = new RedisOpenChatRoomConnectionInfo();
+            CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo = new CachedOpenChatRoomConnectionInfo();
             // when
-            openChatRoomRedisService.createRedisOpenChatRoomConnectionInfo(1L, 1L, redisOpenChatRoomConnectionInfo);
+            openChatRoomRedisService.createRedisOpenChatRoomConnectionInfo(1L, 1L, cachedOpenChatRoomConnectionInfo);
 
             // then
-            verify(openChatRoomRedisRepository).createRedisOpenChatRoomConnectionInfo(1L, 1L, redisOpenChatRoomConnectionInfo);
+            verify(openChatRoomRedisRepository).createRedisOpenChatRoomConnectionInfo(1L, 1L, cachedOpenChatRoomConnectionInfo);
         }
     }
     @Nested
@@ -109,20 +109,20 @@ public class OpenChatRoomRedisServiceImplTest {
     }
     @Nested
     @DisplayName("getRedisOpenChatRoomConnectionInfo 메서드는")
-    class Describe_getRedisOpenChatRoomConnectionInfo{
+    class Describe_getCachedOpenChatRoomConnectionInfo {
         @Test
         @DisplayName("openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo 메서드를 호출한다.")
         void openChatRoomRedisRepositoryd_getRedisOpenChatRoomConnectionInfo_메서드를_호출하고_받은_값을_반환한다(){
             // given
-            RedisOpenChatRoomConnectionInfo redisOpenChatRoomConnectionInfo = new RedisOpenChatRoomConnectionInfo();
-            when(openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo(1L, 1L)).thenReturn(redisOpenChatRoomConnectionInfo);
+            CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo = new CachedOpenChatRoomConnectionInfo();
+            when(openChatRoomRedisRepository.getRedisOpenChatRoomConnectionInfo(1L, 1L)).thenReturn(cachedOpenChatRoomConnectionInfo);
 
             // when
-            RedisOpenChatRoomConnectionInfo result = openChatRoomRedisService.getRedisOpenChatRoomConnectionInfo(1L, 1L);
+            CachedOpenChatRoomConnectionInfo result = openChatRoomRedisService.getRedisOpenChatRoomConnectionInfo(1L, 1L);
 
             // then
             verify(openChatRoomRedisRepository).getRedisOpenChatRoomConnectionInfo(1L, 1L);
-            assertEquals(redisOpenChatRoomConnectionInfo, result);
+            assertEquals(cachedOpenChatRoomConnectionInfo, result);
         }
     }
     @Nested
@@ -159,7 +159,7 @@ public class OpenChatRoomRedisServiceImplTest {
         @DisplayName("openChatRoomRedisRepository.getOpenChatRoom 메서드를 호출한다.")
         void openChatRoomRedisRepositoryd_getOpenChatRoom_메서드를_호출하고_받은_값을_반환한다(){
             // given
-            Optional<RedisOpenChatRoom> redisOpenChatRoom  = Optional.of(new RedisOpenChatRoom(
+            Optional<CachedOpenChatRoom> redisOpenChatRoom  = Optional.of(new CachedOpenChatRoom(
                     1L,
                     "title",
                     "notice",
@@ -172,7 +172,7 @@ public class OpenChatRoomRedisServiceImplTest {
             when(openChatRoomRedisRepository.getOpenChatRoom(1L)).thenReturn(redisOpenChatRoom);
 
             // when
-            Optional<RedisOpenChatRoom> result = openChatRoomRedisService.getOpenChatRoom(1L);
+            Optional<CachedOpenChatRoom> result = openChatRoomRedisService.getOpenChatRoom(1L);
 
             // then
             verify(openChatRoomRedisRepository).getOpenChatRoom(1L);

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
@@ -3,6 +3,7 @@ package com.jongho.openChatRoom.application.service;
 import com.jongho.common.exception.OpenChatRoomNotFoundException;
 import com.jongho.common.exception.UnAuthorizedException;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -234,6 +236,65 @@ public class OpenChatRoomServiceImplTest {
             // when
             // then
             assertThrows(UnAuthorizedException.class, () -> openChatRoomServiceImpl.updateOpenChatRoomNotice(userId, openChatRoomId, notice));
+        }
+    }
+    @Nested
+    @DisplayName("getJoinOpenChatRoomList 메소드는")
+    class Describe_getJoinOpenChatRoomList {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectJoinOpenChatRoomByUserId 메소드를 호출해서 받은 openChatRoom을 반환한다")
+        void OpenChatRoomRepository의_selectJoinOpenChatRoomByUserId메소드를_한번_호출해서_받은_redisOpenChatRoom을_반환한다() {
+            // given
+            Long userId = 1L;
+            List<RedisOpenChatRoom> redisOpenChatRooms = List.of(
+                    new RedisOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56"),
+                    new RedisOpenChatRoom(2L, "타이틀", "공지사항", 1L, 1L, 200, 2, "2024-01-30 12:34:56")
+            );
+            when(openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId)).thenReturn(redisOpenChatRooms);
+
+            // when
+            openChatRoomServiceImpl.getJoinOpenChatRoomList(userId);
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectJoinOpenChatRoomByUserId(userId);
+        }
+    }
+    @Nested
+    @DisplayName("getOpenChatRoomUserList 메소드는")
+    class Describe_getOpenChatRoomUserList {
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectOpenChatRoomUserList 메소드를 호출해서 받은 openChatRoomUserList를 반환한다")
+        void OpenChatRoomRepository의_selectOpenChatRoomUserList메소드를_한번_호출해서_받은_openChatRoomUserList를_반환한다() {
+            // given
+            Long openChatRoomId = 1L;
+            List<Long> userIds = List.of(1L, 2L, 3L);
+            when(openChatRoomRepository.selectOpenChatRoomUser(openChatRoomId)).thenReturn(userIds);
+
+            // when
+            List<Long> result = openChatRoomServiceImpl.getOpenChatRoomUserList(openChatRoomId);
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectOpenChatRoomUser(openChatRoomId);
+            assertEquals(userIds, result);
+        }
+    }
+    @Nested
+    @DisplayName("getRedisOpenChatRoomById 메소드는")
+    class Describe_getRedisOpenChatRoomById{
+        @Test
+        @DisplayName("OpenChatRoomRepository의 selectRedisOpenChatRoomById 메소드를 호출해서 받은 redisOpenChatRoom을 반환한다")
+        void OpenChatRoomRepository의_selectRedisOpenChatRoomById메소드를_한번_호출해서_받은_redisOpenChatRoom을_반환한다() {
+            // given
+            Long openChatRoomId = 1L;
+            RedisOpenChatRoom redisOpenChatRoom = new RedisOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56");
+            when(openChatRoomRepository.selectRedisOpenChatRoomById(openChatRoomId)).thenReturn(Optional.of(redisOpenChatRoom));
+
+            // when
+            RedisOpenChatRoom result = openChatRoomServiceImpl.getRedisOpenChatRoomById(openChatRoomId).get();
+
+            // then
+            verify(openChatRoomRepository, times(1)).selectRedisOpenChatRoomById(openChatRoomId);
+            assertEquals(redisOpenChatRoom, result);
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomServiceImplTest.java
@@ -3,7 +3,7 @@ package com.jongho.openChatRoom.application.service;
 import com.jongho.common.exception.OpenChatRoomNotFoundException;
 import com.jongho.common.exception.UnAuthorizedException;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoom.domain.repository.OpenChatRoomRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -246,11 +246,11 @@ public class OpenChatRoomServiceImplTest {
         void OpenChatRoomRepository의_selectJoinOpenChatRoomByUserId메소드를_한번_호출해서_받은_redisOpenChatRoom을_반환한다() {
             // given
             Long userId = 1L;
-            List<RedisOpenChatRoom> redisOpenChatRooms = List.of(
-                    new RedisOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56"),
-                    new RedisOpenChatRoom(2L, "타이틀", "공지사항", 1L, 1L, 200, 2, "2024-01-30 12:34:56")
+            List<CachedOpenChatRoom> cachedOpenChatRooms = List.of(
+                    new CachedOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56"),
+                    new CachedOpenChatRoom(2L, "타이틀", "공지사항", 1L, 1L, 200, 2, "2024-01-30 12:34:56")
             );
-            when(openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId)).thenReturn(redisOpenChatRooms);
+            when(openChatRoomRepository.selectJoinOpenChatRoomByUserId(userId)).thenReturn(cachedOpenChatRooms);
 
             // when
             openChatRoomServiceImpl.getJoinOpenChatRoomList(userId);
@@ -280,21 +280,21 @@ public class OpenChatRoomServiceImplTest {
     }
     @Nested
     @DisplayName("getRedisOpenChatRoomById 메소드는")
-    class Describe_getRedisOpenChatRoomById{
+    class Describe_getCachedOpenChatRoomById {
         @Test
         @DisplayName("OpenChatRoomRepository의 selectRedisOpenChatRoomById 메소드를 호출해서 받은 redisOpenChatRoom을 반환한다")
         void OpenChatRoomRepository의_selectRedisOpenChatRoomById메소드를_한번_호출해서_받은_redisOpenChatRoom을_반환한다() {
             // given
             Long openChatRoomId = 1L;
-            RedisOpenChatRoom redisOpenChatRoom = new RedisOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56");
-            when(openChatRoomRepository.selectRedisOpenChatRoomById(openChatRoomId)).thenReturn(Optional.of(redisOpenChatRoom));
+            CachedOpenChatRoom cachedOpenChatRoom = new CachedOpenChatRoom(1L, "타이틀", "공지사항", 1L, 1L, 200, 1,"2024-01-30 12:34:56");
+            when(openChatRoomRepository.selectRedisOpenChatRoomById(openChatRoomId)).thenReturn(Optional.of(cachedOpenChatRoom));
 
             // when
-            RedisOpenChatRoom result = openChatRoomServiceImpl.getRedisOpenChatRoomById(openChatRoomId).get();
+            CachedOpenChatRoom result = openChatRoomServiceImpl.getRedisOpenChatRoomById(openChatRoomId).get();
 
             // then
             verify(openChatRoomRepository, times(1)).selectRedisOpenChatRoomById(openChatRoomId);
-            assertEquals(redisOpenChatRoom, result);
+            assertEquals(cachedOpenChatRoom, result);
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
@@ -2,14 +2,21 @@ package com.jongho.openChatRoom.dao.mapper;
 
 import com.jongho.common.dao.BaseMapperTest;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoomUser.dao.mapper.OpenChatRoomUserMapper;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 @DisplayName("OpenChatRoomMapper 인터페이스")
 public class OpenChatRoomMapperTest extends BaseMapperTest {
     @Autowired
     private OpenChatRoomMapper openChatRoomMapper;
+    @Autowired
+    private OpenChatRoomUserMapper openChatRoomUserMapper;
 
     @Nested
     @DisplayName("createOpenChatRoom 메소드는")
@@ -217,6 +224,111 @@ public class OpenChatRoomMapperTest extends BaseMapperTest {
 
             // then
             assertEquals("수정된 공지사항", openChatRoomMapper.selectOneOpenChatRoomById(openChatRoom.getId()).getNotice());
+        }
+    }
+    @Nested
+    @DisplayName("selectJoinOpenChatRoomByUserId 메소드는")
+    class Describe_selectJoinOpenChatRoomByUserId {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+            cleanUpOpenChatRoomUserTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 유저 아이디를 가진 오픈채팅방유저를 반환한다.")
+        void 오픈채팅방유저_리스트를_반환한다() {
+            // given
+            OpenChatRoom openChatRoom1 = new OpenChatRoom(
+                    "타이틀1",
+                    "공지사항1",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            OpenChatRoom openChatRoom2 = new OpenChatRoom(
+                    "타이틀2",
+                    "공지사항2",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom1);
+            openChatRoomMapper.createOpenChatRoom(openChatRoom2);
+            openChatRoomUserMapper.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom1.getId(), 1L));
+            openChatRoomUserMapper.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom2.getId(), 1L));
+
+            // when
+            var result = openChatRoomMapper.selectJoinOpenChatRoomByUserId(1L);
+
+            // then
+            assertEquals(2, result.size());
+        }
+    }
+    @Nested
+    @DisplayName("selectOpenChatRoomUser 메소드는")
+    class Describe_selectOpenChatRoomUser {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+            cleanUpOpenChatRoomUserTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방 아이디를 가진 오픈채팅방유저를 반환한다.")
+        void 오픈채팅방유저_리스트를_반환한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀1",
+                    "공지사항1",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+            openChatRoomUserMapper.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), 1L));
+            openChatRoomUserMapper.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), 2L));
+            openChatRoomUserMapper.createOpenChatRoomUser(new OpenChatRoomUser(openChatRoom.getId(), 3L));
+
+            // when
+            var result = openChatRoomMapper.selectOpenChatRoomUser(openChatRoom.getId());
+
+            // then
+            assertEquals(3, result.size());
+        }
+    }
+    @Nested
+    @DisplayName("selectRedisOpenChatRoomById 메소드는")
+    class Describe_selectRedisOpenChatRoomById {
+        @BeforeEach
+        void setUp() {
+            cleanUpOpenChatRoomTable();
+            cleanUpOpenChatRoomUserTable();
+        }
+
+        @Test
+        @DisplayName("인자로 받은 오픈채팅방 아이디를 가진 오픈채팅방을 반환한다.")
+        void 오픈채팅방을_반환한다() {
+            // given
+            OpenChatRoom openChatRoom = new OpenChatRoom(
+                    "타이틀1",
+                    "공지사항1",
+                    1L,
+                    1L,
+                    200,
+                    "비밀번호"
+            );
+            openChatRoomMapper.createOpenChatRoom(openChatRoom);
+
+            // when
+            var result = openChatRoomMapper.selectRedisOpenChatRoomById(openChatRoom.getId());
+
+            // then
+            assertNotNull(result.getCreatedTime());
+            assertEquals(RedisOpenChatRoom.class, result.getClass());
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/dao/mapper/OpenChatRoomMapperTest.java
@@ -2,7 +2,7 @@ package com.jongho.openChatRoom.dao.mapper;
 
 import com.jongho.common.dao.BaseMapperTest;
 import com.jongho.openChatRoom.domain.model.OpenChatRoom;
-import com.jongho.openChatRoom.domain.model.redis.RedisOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoomUser.dao.mapper.OpenChatRoomUserMapper;
 import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
 import org.junit.jupiter.api.*;
@@ -302,7 +302,7 @@ public class OpenChatRoomMapperTest extends BaseMapperTest {
     }
     @Nested
     @DisplayName("selectRedisOpenChatRoomById 메소드는")
-    class Describe_selectRedisOpenChatRoomById {
+    class Describe_selectCachedOpenChatRoomById {
         @BeforeEach
         void setUp() {
             cleanUpOpenChatRoomTable();
@@ -328,7 +328,7 @@ public class OpenChatRoomMapperTest extends BaseMapperTest {
 
             // then
             assertNotNull(result.getCreatedTime());
-            assertEquals(RedisOpenChatRoom.class, result.getClass());
+            assertEquals(CachedOpenChatRoom.class, result.getClass());
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapperTest.java
+++ b/api/src/test/java/com/jongho/openChatRoomUser/dao/mapper/OpenChatRoomUserMapperTest.java
@@ -31,12 +31,16 @@ public class OpenChatRoomUserMapperTest extends BaseMapperTest {
                     1L,
                     2L
             );
-
-            // when
             openChatRoomUserMapper.createOpenChatRoomUser(openChatRoomUser);
 
+            // when
+
+            OpenChatRoomUser selectOpenChatRoomUser = openChatRoomUserMapper.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(
+                    openChatRoomUser.getOpenChatRoomId(),
+                    openChatRoomUser.getUserId());
             // then
-            assertEquals(openChatRoomUser, openChatRoomUserMapper.selectOneOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoomUser.getOpenChatRoomId(), openChatRoomUser.getUserId()));
+            assertEquals(openChatRoomUser.getUserId(), selectOpenChatRoomUser.getUserId());
+            assertEquals(openChatRoomUser.getOpenChatRoomId(), selectOpenChatRoomUser.getOpenChatRoomId());
         }
     }
 }

--- a/api/src/test/java/com/jongho/user/dao/mapper/UserMapperTest.java
+++ b/api/src/test/java/com/jongho/user/dao/mapper/UserMapperTest.java
@@ -64,7 +64,6 @@ public class UserMapperTest extends BaseMapperTest {
             User user = new User("jonghao", "a123b123", "whdgh9595", "01012341234", null);
 
             // when
-            System.out.println(user.getId());
             userMapper.createUser(user);
             User selectUser = userMapper.findOneById(user.getId());
 


### PR DESCRIPTION
## 기능 정의
웹소켓 설정 클래스 작성
웹소켓 연결전 유저인증 인터셉터 작성
채팅룸 조인 기능을 추가하였습니다.

레디스 키 설계
1. chatRooms:{chatRoomId} = {기존 스키마} = 채팅방 정보 
2. chatRooms:{chatRoomId}:users = [Long] = 유저리스트 
3. chatRooms:{chatRoomId}:lastMessage = 객체 = 채팅방의
4. users:{userId}:chatRooms = [Long] = 참여중인 채팅방
5. users:{userId}:chatRooms:{chatRoomId}:connectionInfo = {active: 1, lastExitDate: 2023~~~~, unReadCount = 0} = 유저 접속정보

redis 데이터를 불러올수 있는 service, repository를 작성하였습니다.

## 주요 변경 및 추가 사항
웹소켓 연결전 유저 인증을 위한 핸드셰이크 인터셉터를 작성하였습니다.
웹소켓 연결시 채팅방 리스트를 반환받을수 있는 join 관련 로직을 작성하였습니다.

## 테스트
join시 필요한 OpenChatRoom의 application, dao 로직의 테스트코드를 작성하였습니다.
join시 필요한 OpenChat의 application 로직의 테스트코드를 작성하였습니다.

## 블로커
레디스 키 설계에 막힌점이 블로커입니다.  커밋을 지우고 다시 만들고의 과정이 반복되었습니다.

## 미흡한점

