### PR TITLE
[ADD]웹소켓 오픈채팅 기능 작성

### DIFF
--- a/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
+++ b/api/src/main/java/com/jongho/common/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.jongho.common.config;
 
 import com.jongho.common.interceptor.WebSocketAuthInterceptor;
+import com.jongho.common.interceptor.WebSocketPathVariablesInterceptor;
 import com.jongho.openChat.handler.WebSocketOpenChatHandler;
 import com.jongho.openChatRoom.handler.WebSocketOpenChatRoomHandler;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +15,15 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final WebSocketPathVariablesInterceptor webSocketPathVariablesInterceptor;
     private final WebSocketOpenChatHandler webSocketOpenChatHandler;
     private final WebSocketOpenChatRoomHandler webSocketOpenChatRoomHandler;
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(webSocketOpenChatRoomHandler, "/open-chat-rooms")
-                .addHandler(webSocketOpenChatHandler, "/open-chats")
+                .addHandler(webSocketOpenChatHandler, "/open-chat-rooms/*/open-chats")
                 .addInterceptors(webSocketAuthInterceptor)
+                .addInterceptors(webSocketPathVariablesInterceptor)
                 .setAllowedOrigins("*");
     }
 }

--- a/api/src/main/java/com/jongho/common/database/redis/RedisService.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisService.java
@@ -1,8 +1,6 @@
 package com.jongho.common.database.redis;
 
-import com.jongho.common.exception.MyJsonProcessingException;
 import com.jongho.common.util.websocket.BaseWebSocketMessage;
-import com.jongho.openChat.application.dto.OpenChatDto;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -12,5 +10,7 @@ public interface RedisService {
     public void publish(String channel, String message);
     public void subscribe(String channel, WebSocketSession session);
     public void subscribe(List<String> channel, WebSocketSession session);
-    public BaseWebSocketMessage<OpenChatDto> convertStringMessageToBaseWebSocketMessage(TextMessage message);
+    public BaseWebSocketMessage convertStringMessageToBaseWebSocketMessage(TextMessage message);
+    public <T> T dataToObject(String data, Class<T> valueType);
+    public String objectToData(Object object);
 }

--- a/api/src/main/java/com/jongho/common/database/redis/RedisService.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisService.java
@@ -1,5 +1,9 @@
 package com.jongho.common.database.redis;
 
+import com.jongho.common.exception.MyJsonProcessingException;
+import com.jongho.common.util.websocket.BaseWebSocketMessage;
+import com.jongho.openChat.application.dto.OpenChatDto;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.List;
@@ -8,4 +12,5 @@ public interface RedisService {
     public void publish(String channel, String message);
     public void subscribe(String channel, WebSocketSession session);
     public void subscribe(List<String> channel, WebSocketSession session);
+    public BaseWebSocketMessage<OpenChatDto> convertStringMessageToBaseWebSocketMessage(TextMessage message);
 }

--- a/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
@@ -1,6 +1,12 @@
 package com.jongho.common.database.redis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.jongho.common.exception.MyJsonProcessingException;
 import com.jongho.common.util.redis.BaseRedisTemplate;
+import com.jongho.common.util.websocket.BaseWebSocketMessage;
+import com.jongho.openChat.application.dto.OpenChatDto;
+import com.jongho.openChat.domain.model.OpenChat;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
@@ -29,6 +35,9 @@ public class RedisServiceImpl implements RedisService{
 
     private RedisMessageHandler getMessageHandler(WebSocketSession session) {
         return new RedisMessageHandler(session);
+    }
+    public BaseWebSocketMessage<OpenChatDto> convertStringMessageToBaseWebSocketMessage(TextMessage message){
+        return baseRedisTemplate.getWebSocketMessage(message);
     }
 }
 

--- a/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/common/database/redis/RedisServiceImpl.java
@@ -1,12 +1,7 @@
 package com.jongho.common.database.redis;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
-import com.jongho.common.exception.MyJsonProcessingException;
 import com.jongho.common.util.redis.BaseRedisTemplate;
 import com.jongho.common.util.websocket.BaseWebSocketMessage;
-import com.jongho.openChat.application.dto.OpenChatDto;
-import com.jongho.openChat.domain.model.OpenChat;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
@@ -36,8 +31,14 @@ public class RedisServiceImpl implements RedisService{
     private RedisMessageHandler getMessageHandler(WebSocketSession session) {
         return new RedisMessageHandler(session);
     }
-    public BaseWebSocketMessage<OpenChatDto> convertStringMessageToBaseWebSocketMessage(TextMessage message){
+    public BaseWebSocketMessage convertStringMessageToBaseWebSocketMessage(TextMessage message){
         return baseRedisTemplate.getWebSocketMessage(message);
+    }
+    public <T> T dataToObject(String data, Class<T> valueType){
+        return baseRedisTemplate.toObject(data, valueType);
+    }
+    public String objectToData(Object object){
+        return baseRedisTemplate.toJson(object);
     }
 }
 

--- a/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
+++ b/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
@@ -1,0 +1,68 @@
+package com.jongho.common.interceptor;
+
+import com.google.gson.Gson;
+import com.jongho.common.response.BaseResponseEntity;
+import com.jongho.openChatRoom.application.service.OpenChatRoomService;
+import com.jongho.openChatRoom.domain.model.OpenChatRoom;
+import com.jongho.openChatRoomUser.application.service.OpenChatRoomUserService;
+import com.jongho.openChatRoomUser.domain.model.OpenChatRoomUser;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketPathVariablesInterceptor implements HandshakeInterceptor {
+    private final OpenChatRoomService openChatRoomService;
+    private final OpenChatRoomUserService openChatRoomUserService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+            String path = servletRequest.getURI().getPath();
+            String[] pathVariables = path.split("/");
+            if (pathVariables.length < 2) {
+                return true;
+            }
+
+            Long openChatRoomId = Long.parseLong(pathVariables[pathVariables.length - 2]);
+            Optional<OpenChatRoom> openChatRoom = openChatRoomService.getOpenChatRoomById(openChatRoomId);
+            if (openChatRoom.isEmpty()) {
+                return handleInvalidChatRoom(servletResponse, "존재하지 않는 채팅방입니다.");
+            }
+            Optional<OpenChatRoomUser> userId = openChatRoomUserService.getOpenChatRoomUserByOpenChatRoomIdAndUserId(openChatRoom.get().getId(), (Long) attributes.get("userId"));
+            if (userId.isEmpty()) {
+                return handleInvalidChatRoom(servletResponse, "채팅방에 참여하지 않은 사용자입니다.");
+            }
+            attributes.put("openChatRoomId", openChatRoom.get().getId());
+        }
+
+        return true;
+    }
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception ex) {
+    }
+
+    private boolean handleInvalidChatRoom(HttpServletResponse response, String errorMessage) throws IOException {
+        String result = new Gson().toJson(BaseResponseEntity.fail(HttpStatus.NOT_FOUND, errorMessage).getBody());
+        response.setStatus(HttpStatus.NOT_FOUND.value());
+        response.setContentType("application/json; charset=UTF-8");
+        PrintWriter writer = response.getWriter();
+        writer.println(result);
+
+        return false;
+    }
+}

--- a/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
+++ b/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
@@ -48,7 +48,12 @@ public class WebSocketPathVariablesInterceptor implements HandshakeInterceptor {
             }
 
             String[] pathVariables = path.split("/");
-            Long openChatRoomId = Long.parseLong(pathVariables[pathVariables.length - 2]);
+            Long openChatRoomId;
+            try {
+                openChatRoomId = Long.parseLong(pathVariables[pathVariables.length - 2]);
+            } catch (NumberFormatException e) {
+
+            }
             Optional<OpenChatRoom> openChatRoom = openChatRoomService.getOpenChatRoomById(openChatRoomId);
             if (openChatRoom.isEmpty()) {
                 log.error("404 Not Foud chatRoomId: {}", openChatRoomId);

--- a/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
+++ b/api/src/main/java/com/jongho/common/interceptor/WebSocketPathVariablesInterceptor.java
@@ -40,13 +40,14 @@ public class WebSocketPathVariablesInterceptor implements HandshakeInterceptor {
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
         if (request instanceof ServletServerHttpRequest servletRequest) {
+            String OPEN_CHAT_ROOM_ENDPOIND = "/open-chat-rooms";
             HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
             String path = servletRequest.getURI().getPath();
-            String[] pathVariables = path.split("/");
-            if (pathVariables.length < 2) {
+            if(path.equals(OPEN_CHAT_ROOM_ENDPOIND)){
                 return true;
             }
 
+            String[] pathVariables = path.split("/");
             Long openChatRoomId = Long.parseLong(pathVariables[pathVariables.length - 2]);
             Optional<OpenChatRoom> openChatRoom = openChatRoomService.getOpenChatRoomById(openChatRoomId);
             if (openChatRoom.isEmpty()) {

--- a/api/src/main/java/com/jongho/common/util/date/DateUtil.java
+++ b/api/src/main/java/com/jongho/common/util/date/DateUtil.java
@@ -9,4 +9,7 @@ public class DateUtil {
 
         return LocalDateTime.parse(stringDate, formatter);
     }
+    public static String now() {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -47,6 +47,17 @@ public class BaseRedisTemplate {
         return result;
     }
 
+    public <T> List<T> getReverseRangeListData(String key, Class<T> valueType, int offset, int limit) {
+        List<String> jsonValue = stringRedisTemplate.opsForList().range(key, offset, limit);
+        if(jsonValue == null){
+            return null;
+        }
+        List<T> result = mappingToElement(jsonValue, valueType);
+        Collections.reverse(result);
+
+        return result;
+    }
+
     public <T> void setAllListData(String key, List<T> value) {
         stringRedisTemplate.opsForList().rightPushAll(key, value.stream().map(this::toJson).collect(Collectors.toList()));
     }
@@ -65,6 +76,10 @@ public class BaseRedisTemplate {
 
     public void setHashData(String key, Map<String, String> value) {
         stringRedisTemplate.opsForHash().putAll(key, value);
+    }
+
+    public <T> void setHashDataColumn(String key, String column, T value) {
+        stringRedisTemplate.opsForHash().put(key, column, value);
     }
 
     public <T> T getHashData(String key, Class<T> valueType) {

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -1,12 +1,15 @@
 package com.jongho.common.util.redis;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jongho.common.exception.MyJsonProcessingException;
+import com.jongho.common.util.websocket.BaseWebSocketMessage;
+import com.jongho.openChat.application.dto.OpenChatDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.TextMessage;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -81,6 +84,9 @@ public class BaseRedisTemplate {
     public <T> void setHashDataColumn(String key, String column, T value) {
         stringRedisTemplate.opsForHash().put(key, column, value);
     }
+    public void incrementHashDataColumn(String key, String column, int value) {
+        stringRedisTemplate.opsForHash().increment(key, column, value);
+    }
 
     public <T> T getHashData(String key, Class<T> valueType) {
         Map<Object, Object> map = stringRedisTemplate.opsForHash().entries(key);
@@ -126,6 +132,16 @@ public class BaseRedisTemplate {
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }
+    }
+
+    public BaseWebSocketMessage<OpenChatDto> getWebSocketMessage(TextMessage textMessage){
+        try {
+            JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseWebSocketMessage.class, OpenChatDto.class);
+            return objectMapper.readValue(textMessage.getPayload(), javaType);
+        }catch (Exception e) {
+            throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
+        }
+
     }
 
     private <T> List<T> mappingToElement(Collection<String> jsonList, Class<T> valueType){

--- a/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
+++ b/api/src/main/java/com/jongho/common/util/redis/BaseRedisTemplate.java
@@ -134,10 +134,9 @@ public class BaseRedisTemplate {
         }
     }
 
-    public BaseWebSocketMessage<OpenChatDto> getWebSocketMessage(TextMessage textMessage){
+    public BaseWebSocketMessage getWebSocketMessage(TextMessage textMessage){
         try {
-            JavaType javaType = objectMapper.getTypeFactory().constructParametricType(BaseWebSocketMessage.class, OpenChatDto.class);
-            return objectMapper.readValue(textMessage.getPayload(), javaType);
+            return objectMapper.readValue(textMessage.getPayload(), BaseWebSocketMessage.class);
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }

--- a/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
+++ b/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
@@ -20,6 +20,6 @@ public class RedisKeyGeneration {
         return "chatRooms:" + openChatRoomId + ":users";
     }
     public static String getUserProfileKey(Long userId) {
-        return "users:" + userId;
+        return "users:" + userId + ":profile";
     }
 }

--- a/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
+++ b/api/src/main/java/com/jongho/common/util/redis/RedisKeyGeneration.java
@@ -19,4 +19,7 @@ public class RedisKeyGeneration {
     public static String getChatRoomUserListKey(Long openChatRoomId) {
         return "chatRooms:" + openChatRoomId + ":users";
     }
+    public static String getUserProfileKey(Long userId) {
+        return "users:" + userId;
+    }
 }

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseMessageTypeEnum.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseMessageTypeEnum.java
@@ -2,6 +2,7 @@ package com.jongho.common.util.websocket;
 
 public enum BaseMessageTypeEnum {
     SEND("SEND"),
+    PAGINATION("PAGINATION"),
     RECEIVE("RECEIVE"),
     JOIN("JOIN"),
     LEAVE("LEAVE"),

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
@@ -10,21 +10,22 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class BaseWebSocketMessage<T> {
+public class BaseWebSocketMessage {
     private final BaseMessageTypeEnum type;
-    private final T data;
+    private final String data;
     public static ObjectMapper objectMapper = new ObjectMapper();
     @JsonCreator
     public BaseWebSocketMessage(
             @JsonProperty("type") BaseMessageTypeEnum type,
-            @JsonProperty("data") T data) {
+            @JsonProperty("data") String data) {
         this.type = type;
         this.data = data;
     }
 
     public static <T> String of(BaseMessageTypeEnum baseMessageTypeEnum, T data) {
         try {
-            return objectMapper.writeValueAsString(new BaseWebSocketMessage<>(baseMessageTypeEnum, data));
+            String stringData = objectMapper.writeValueAsString(data);
+            return objectMapper.writeValueAsString(new BaseWebSocketMessage(baseMessageTypeEnum, stringData));
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }

--- a/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
+++ b/api/src/main/java/com/jongho/common/util/websocket/BaseWebSocketMessage.java
@@ -1,5 +1,7 @@
 package com.jongho.common.util.websocket;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jongho.common.exception.MyJsonProcessingException;
 import lombok.Getter;
@@ -8,15 +10,21 @@ import lombok.ToString;
 
 @Getter
 @ToString
-@RequiredArgsConstructor
 public class BaseWebSocketMessage<T> {
     private final BaseMessageTypeEnum type;
     private final T data;
     public static ObjectMapper objectMapper = new ObjectMapper();
+    @JsonCreator
+    public BaseWebSocketMessage(
+            @JsonProperty("type") BaseMessageTypeEnum type,
+            @JsonProperty("data") T data) {
+        this.type = type;
+        this.data = data;
+    }
 
-    public static <T> String of(T data) {
+    public static <T> String of(BaseMessageTypeEnum baseMessageTypeEnum, T data) {
         try {
-            return objectMapper.writeValueAsString(new BaseWebSocketMessage<T>(BaseMessageTypeEnum.JOIN, data));
+            return objectMapper.writeValueAsString(new BaseWebSocketMessage<>(baseMessageTypeEnum, data));
         }catch (Exception e) {
             throw new MyJsonProcessingException(e.getMessage()!=null? e.getMessage():"json processing error");
         }

--- a/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
+++ b/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jongho.user.domain.model.redis.CachedUserProfile;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
+@Setter
 @ToString
 @RequiredArgsConstructor
 public class OpenChatDto {
@@ -38,6 +40,27 @@ public class OpenChatDto {
         this.deletedTime = deletedTime;
         this.createdTime = createdTime;
         this.senderProfile = senderProfile;
+    }
+
+    public OpenChatDto(
+            Long id,
+            Long openChatRoomId,
+            String message,
+            int type,
+            int isDeleted,
+            String deletedTime,
+            String createdTime,
+            Long sender_id,
+            String sender_nickname,
+            String sender_profileImage) {
+        this.id = id;
+        this.openChatRoomId = openChatRoomId;
+        this.message = message;
+        this.type = type;
+        this.isDeleted = isDeleted;
+        this.deletedTime = deletedTime;
+        this.createdTime = createdTime;
+        this.senderProfile = new CachedUserProfile(sender_id, sender_nickname, sender_profileImage);
     }
 
     public void setSenderProfile(CachedUserProfile senderProfile) {

--- a/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
+++ b/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
@@ -2,11 +2,14 @@ package com.jongho.openChat.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jongho.user.domain.model.redis.CachedUserProfile;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@RequiredArgsConstructor
 public class OpenChatDto {
     private final Long id;
     private final Long openChatRoomId;
@@ -15,19 +18,18 @@ public class OpenChatDto {
     private final int isDeleted;
     private final String deletedTime;
     private final String createdTime;
-    private final SenderInfo senderInfo;
+    private CachedUserProfile senderProfile;
 
     @JsonCreator
     public OpenChatDto(
             @JsonProperty("id") Long id,
-            @JsonProperty("senderId") Long senderId,
             @JsonProperty("openChatRoomId") Long openChatRoomId,
             @JsonProperty("message") String message,
             @JsonProperty("type") int type,
             @JsonProperty("isDeleted") int isDeleted,
             @JsonProperty("deletedTime") String deletedTime,
             @JsonProperty("createdTime") String createdTime,
-            @JsonProperty("senderInfo") SenderInfo senderInfo) {
+            @JsonProperty("senderProfile") CachedUserProfile senderProfile) {
         this.id = id;
         this.openChatRoomId = openChatRoomId;
         this.message = message;
@@ -35,24 +37,10 @@ public class OpenChatDto {
         this.isDeleted = isDeleted;
         this.deletedTime = deletedTime;
         this.createdTime = createdTime;
-        this.senderInfo = senderInfo;
+        this.senderProfile = senderProfile;
     }
-}
 
-@Getter
-@ToString
-class SenderInfo {
-    private final Long senderId;
-    private final String nickname;
-    private final String profileImage;
-
-    @JsonCreator
-    public SenderInfo(
-            @JsonProperty("senderId") Long senderId,
-            @JsonProperty("nickname") String name,
-            @JsonProperty("profileImage") String profileImage) {
-        this.senderId = senderId;
-        this.nickname = name;
-        this.profileImage = profileImage;
+    public void setSenderProfile(CachedUserProfile senderProfile) {
+        this.senderProfile = senderProfile;
     }
 }

--- a/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
+++ b/api/src/main/java/com/jongho/openChat/application/dto/OpenChatDto.java
@@ -1,0 +1,58 @@
+package com.jongho.openChat.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class OpenChatDto {
+    private final Long id;
+    private final Long openChatRoomId;
+    private final String message;
+    private final int type;
+    private final int isDeleted;
+    private final String deletedTime;
+    private final String createdTime;
+    private final SenderInfo senderInfo;
+
+    @JsonCreator
+    public OpenChatDto(
+            @JsonProperty("id") Long id,
+            @JsonProperty("senderId") Long senderId,
+            @JsonProperty("openChatRoomId") Long openChatRoomId,
+            @JsonProperty("message") String message,
+            @JsonProperty("type") int type,
+            @JsonProperty("isDeleted") int isDeleted,
+            @JsonProperty("deletedTime") String deletedTime,
+            @JsonProperty("createdTime") String createdTime,
+            @JsonProperty("senderInfo") SenderInfo senderInfo) {
+        this.id = id;
+        this.openChatRoomId = openChatRoomId;
+        this.message = message;
+        this.type = type;
+        this.isDeleted = isDeleted;
+        this.deletedTime = deletedTime;
+        this.createdTime = createdTime;
+        this.senderInfo = senderInfo;
+    }
+}
+
+@Getter
+@ToString
+class SenderInfo {
+    private final Long senderId;
+    private final String nickname;
+    private final String profileImage;
+
+    @JsonCreator
+    public SenderInfo(
+            @JsonProperty("senderId") Long senderId,
+            @JsonProperty("nickname") String name,
+            @JsonProperty("profileImage") String profileImage) {
+        this.senderId = senderId;
+        this.nickname = name;
+        this.profileImage = profileImage;
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/application/dto/request/PaginationDto.java
+++ b/api/src/main/java/com/jongho/openChat/application/dto/request/PaginationDto.java
@@ -1,0 +1,24 @@
+package com.jongho.openChat.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class PaginationDto {
+    private final int offset;
+    private final int limit;
+    private final String lastCreatedTime;
+
+    @JsonCreator
+    public PaginationDto(
+            @JsonProperty("offset") int offset,
+            @JsonProperty("limit") int limit,
+            @JsonProperty("last_created_time") String lastCreatedTime) {
+        this.offset = offset;
+        this.limit = limit;
+        this.lastCreatedTime = lastCreatedTime;
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacade.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacade.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ReadWebSocketOpenChatFacade {
     public List<OpenChatDto> getInitialOpenChatList(Long openChatRoomId);
+    public List<OpenChatDto> getOpenChatListByOpenChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime);
 }

--- a/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacade.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacade.java
@@ -4,6 +4,6 @@ import com.jongho.openChat.application.dto.OpenChatDto;
 
 import java.util.List;
 
-public interface WebSocketOpenChatFacade {
+public interface ReadWebSocketOpenChatFacade {
     public List<OpenChatDto> getInitialOpenChatList(Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
@@ -5,7 +5,6 @@ import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.application.service.OpenChatRedisService;
 import com.jongho.openChat.application.service.OpenChatService;
 import com.jongho.openChat.domain.model.OpenChat;
-import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
 import com.jongho.user.application.service.UserRedisService;
 import com.jongho.user.application.service.UserService;
 import com.jongho.user.domain.model.User;
@@ -24,7 +23,6 @@ import java.util.stream.Stream;
 public class ReadWebSocketOpenChatFacadeImpl implements ReadWebSocketOpenChatFacade {
     private final OpenChatService openChatService;
     private final OpenChatRedisService openChatRedisService;
-    private final OpenChatRoomRedisService openChatRoomRedisService;
     private final UserRedisService userRedisService;
     private final UserService userService;
     private final int limit = 100;
@@ -86,6 +84,7 @@ public class ReadWebSocketOpenChatFacadeImpl implements ReadWebSocketOpenChatFac
         List<OpenChat> filterList = openChatList
                 .stream()
                 .filter(openChat -> DateUtil.convertStringToDate(openChat.getCreatedTime()).isAfter(DateUtil.convertStringToDate(lastCreatedTime)))
+                .limit(limit)
                 .toList();
 
         return getOpenChatDtoList(filterList);

--- a/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-public class WebSocketOpenChatFacadeImpl implements WebSocketOpenChatFacade{
+public class ReadWebSocketOpenChatFacadeImpl implements ReadWebSocketOpenChatFacade {
     private final OpenChatService openChatService;
     private final OpenChatRedisService openChatRedisService;
     private final OpenChatRoomRedisService openChatRoomRedisService;

--- a/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/ReadWebSocketOpenChatFacadeImpl.java
@@ -53,6 +53,12 @@ public class ReadWebSocketOpenChatFacadeImpl implements ReadWebSocketOpenChatFac
                 openChatDtos
         );
     }
+    /**
+     * PAGINATION을 위한 채팅 목록을 가져온다.
+     * @param openChatRoomId 채팅방 아이디
+     * @param lastCreatedTime 마지막 생성 시간
+     * @return 채팅 목록
+     */
     @Override
     public List<OpenChatDto> getOpenChatListByOpenChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime){
         List<OpenChat> openChatList = openChatRedisService.getOpenChatListByOpenChatRoomId(openChatRoomId);

--- a/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacade.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacade.java
@@ -1,0 +1,7 @@
+package com.jongho.openChat.application.facade;
+
+import com.jongho.openChat.application.dto.OpenChatDto;
+
+public interface SendWebSocketOpenChatFacade {
+    public void sendOpenChat(OpenChatDto openChatDto);
+}

--- a/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacadeImpl.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.jongho.openChatRoom.common.enums.ActiveTypeEnum.INACTIVE;
+
 @Service
 @Log4j2
 @RequiredArgsConstructor
@@ -84,9 +86,8 @@ public class SendWebSocketOpenChatFacadeImpl implements SendWebSocketOpenChatFac
      * @param openChatRoomId 채팅방 ID
      */
     public void increaseUnreadMessageCountForInactiveChatRoom(Long userId, Long openChatRoomId) {
-        int INACTIVE = 0;
         CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo = getOpenChatRoomConnectionInfo(userId, openChatRoomId);
-        if (cachedOpenChatRoomConnectionInfo != null && cachedOpenChatRoomConnectionInfo.getActive() == INACTIVE) {
+        if (cachedOpenChatRoomConnectionInfo != null && cachedOpenChatRoomConnectionInfo.getActive() == INACTIVE.getType()) {
             openChatRoomRedisService.incrementUnreadMessageCount(userId, openChatRoomId);
         }
     }

--- a/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/SendWebSocketOpenChatFacadeImpl.java
@@ -1,0 +1,111 @@
+package com.jongho.openChat.application.facade;
+
+import com.jongho.common.exception.OpenChatRoomNotFoundException;
+import com.jongho.openChat.application.dto.OpenChatDto;
+import com.jongho.openChat.application.service.OpenChatRedisService;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
+import com.jongho.openChatRoom.application.service.OpenChatRoomService;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
+import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class SendWebSocketOpenChatFacadeImpl implements SendWebSocketOpenChatFacade{
+    private final OpenChatRedisService openChatRedisService;
+    private final OpenChatRoomRedisService openChatRoomRedisService;
+    private final OpenChatRoomService openChatRoomService;
+
+    /**
+     * 채팅방에 채팅을 전송한다.
+     * @param openChatDto 새로 생성된 채팅 정보
+     */
+    @Override
+    public void sendOpenChat(OpenChatDto openChatDto){
+        OpenChat openChat = convertToOpenChat(openChatDto);
+        openChatRedisService.createOpenChat(openChat);
+        openChatRedisService.updateLastOpenChat(openChat);
+        increaseUnreadMessageCountForAllUsersInChatRoom(openChat);
+    }
+
+    /**
+     * 채팅방의 유저들의 안읽은 메세지를 증가시키는 메소드
+     * @param openChat 새로 생성된 채팅
+     */
+    private void increaseUnreadMessageCountForAllUsersInChatRoom(OpenChat openChat) {
+        getChatRoomUserList(openChat.getOpenChatRoomId())
+                .forEach(userId -> increaseUnreadMessageCountForInactiveChatRoom(userId, openChat.getOpenChatRoomId()));
+    }
+
+    /**
+     * Cache or DB에서 채팅방의 유저 리스트를 가져오는 메소드
+     * @param openChatRoomId 채팅방 ID
+     * @return 채팅방의 유저 리스트
+     */
+    private List<Long> getChatRoomUserList(Long openChatRoomId) {
+        CachedOpenChatRoom cachedOpenChatRoom = getOpenChatRoom(openChatRoomId);
+        List<Long> userIdList = openChatRoomRedisService.getOpenChatRoomUserList(openChatRoomId);
+        if(cachedOpenChatRoom.getCurrentAttendance() != userIdList.size()){
+            userIdList = openChatRoomService.getOpenChatRoomUserList(openChatRoomId);
+        }
+        return  userIdList;
+    }
+
+    /**
+     * Cache or DB에서 채팅방을 가져오는 메소드
+     * @param openChatRoomId 채팅방 ID
+     * @return 채팅방
+     */
+    private CachedOpenChatRoom getOpenChatRoom(Long openChatRoomId) {
+        return openChatRoomRedisService.getOpenChatRoom(openChatRoomId)
+                .orElseGet(()-> openChatRoomService.getRedisOpenChatRoomById(openChatRoomId)
+                        .orElseThrow(()-> new OpenChatRoomNotFoundException("채팅방을 찾을 수 없습니다.")));
+    }
+
+    /**
+     * Cache 에서 채팅방의 유저의 연결 정보를 가져오는 메소드
+     * @param userId 사용자 ID
+     * @param openChatRoomId 채팅방 ID
+     * @return 채팅방의 유저의 연결 정보
+     */
+    private CachedOpenChatRoomConnectionInfo getOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId) {
+        return openChatRoomRedisService.getRedisOpenChatRoomConnectionInfo(userId, openChatRoomId);
+    }
+
+    /**
+     * 채팅방의 안읽은 메세지를 증가시키는 메소드
+     * @param userId 사용자 ID
+     * @param openChatRoomId 채팅방 ID
+     */
+    public void increaseUnreadMessageCountForInactiveChatRoom(Long userId, Long openChatRoomId) {
+        int INACTIVE = 0;
+        CachedOpenChatRoomConnectionInfo cachedOpenChatRoomConnectionInfo = getOpenChatRoomConnectionInfo(userId, openChatRoomId);
+        if (cachedOpenChatRoomConnectionInfo != null && cachedOpenChatRoomConnectionInfo.getActive() == INACTIVE) {
+            openChatRoomRedisService.incrementUnreadMessageCount(userId, openChatRoomId);
+        }
+    }
+
+    /**
+     * OpenChatDto를 OpenChat으로 변환하는 메소드
+     * @param openChatDto OpenChatDto
+     * @return OpenChat
+     *
+     */
+    private OpenChat convertToOpenChat(OpenChatDto openChatDto) {
+        return new OpenChat(
+                openChatDto.getId(),
+                openChatDto.getSenderProfile().getId(),
+                openChatDto.getOpenChatRoomId(),
+                openChatDto.getMessage(),
+                openChatDto.getType(),
+                openChatDto.getIsDeleted(),
+                openChatDto.getDeletedTime(),
+                openChatDto.getCreatedTime());
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/application/facade/WebSocketOpenChatFacade.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/WebSocketOpenChatFacade.java
@@ -1,0 +1,9 @@
+package com.jongho.openChat.application.facade;
+
+import com.jongho.openChat.application.dto.OpenChatDto;
+
+import java.util.List;
+
+public interface WebSocketOpenChatFacade {
+    public List<OpenChatDto> getInitialOpenChatList(Long openChatRoomId);
+}

--- a/api/src/main/java/com/jongho/openChat/application/facade/WebSocketOpenChatFacadeImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/facade/WebSocketOpenChatFacadeImpl.java
@@ -1,0 +1,121 @@
+package com.jongho.openChat.application.facade;
+
+import com.jongho.common.util.date.DateUtil;
+import com.jongho.openChat.application.dto.OpenChatDto;
+import com.jongho.openChat.application.service.OpenChatRedisService;
+import com.jongho.openChat.application.service.OpenChatService;
+import com.jongho.openChat.domain.model.OpenChat;
+import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
+import com.jongho.user.application.service.UserRedisService;
+import com.jongho.user.application.service.UserService;
+import com.jongho.user.domain.model.User;
+import com.jongho.user.domain.model.redis.CachedUserProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class WebSocketOpenChatFacadeImpl implements WebSocketOpenChatFacade{
+    private final OpenChatService openChatService;
+    private final OpenChatRedisService openChatRedisService;
+    private final OpenChatRoomRedisService openChatRoomRedisService;
+    private final UserRedisService userRedisService;
+    private final UserService userService;
+    private final int limit = 100;
+
+    /**
+     * 최근 채팅 목록을 가져온다.
+     * @param openChatRoomId 채팅방 아이디
+     * @return 채팅 목록
+     */
+    @Override
+    public List<OpenChatDto> getInitialOpenChatList(Long openChatRoomId){
+        List<OpenChat> openChatList = openChatRedisService.getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(openChatRoomId, 0, limit-1);
+        if(openChatList.size() == 0){
+            return openChatService.getOpenChatByOpenChatRoomIdAndLastCreatedTime(openChatRoomId, DateUtil.now(), limit);
+        }
+        List<OpenChatDto> openChatDtoList = getOpenChatDtoList(openChatList);
+        if(openChatDtoList.size() >= limit){
+
+            return openChatDtoList;
+        }
+
+        List<OpenChatDto> openChatDtos = openChatService.getOpenChatByOpenChatRoomIdAndLastCreatedTime(openChatRoomId, DateUtil.now(), limit - openChatDtoList.size());
+
+        return getMergeOepnChatDtoList(
+                openChatDtoList,
+                openChatDtos
+        );
+    }
+
+    /**
+     * OpenChat을 OpenChatDto로 변환후 반환한다.
+     * @param openChatList List<OpenChat>
+     * @return 채팅 목록
+     */
+    private List<OpenChatDto> getOpenChatDtoList(List<OpenChat> openChatList){
+        return openChatList
+                .stream()
+                .map(this::convertOpenChatToOpenChatDto)
+                .toList();
+    }
+
+    /**
+     * OpenChat을 OpenChatDto로 변환한다.
+     * @param openChat OpenChat
+     * @return OpenChatDto
+     */
+    private OpenChatDto convertOpenChatToOpenChatDto(OpenChat openChat) {
+        CachedUserProfile cachedUserProfile = userRedisService.getUserProfileByUserId(openChat.getSenderId());
+        OpenChatDto openChatDto = new OpenChatDto(
+                openChat.getId(),
+                openChat.getOpenChatRoomId(),
+                openChat.getMessage(),
+                openChat.getType(),
+                openChat.getIsDeleted(),
+                openChat.getDeletedTime(),
+                openChat.getCreatedTime()
+        );
+        if (cachedUserProfile != null) {
+            openChatDto.setSenderProfile(cachedUserProfile);
+        }
+        else{
+            openChatDto.setSenderProfile(getSenderProfile(openChat.getSenderId(), openChatDto));
+        }
+
+        return openChatDto;
+    }
+
+    /**
+     * 캐시에 없는 유저의 프로필을 가져온다.
+     * @param senderId 유저 아이디
+     * @param openChatDto OpenChatDto
+     * @return CachedUserProfile
+     */
+    private CachedUserProfile getSenderProfile(Long senderId, OpenChatDto openChatDto) {
+            Optional<User> optionalUser = userService.getUserById(senderId);
+        return optionalUser
+                .map(user ->{
+                    userRedisService.createUserProfileByUserId(user.getId(), user.getNickname(), user.getProfileImage());
+                    return new CachedUserProfile(user.getId(), user.getNickname(), user.getProfileImage());
+                })
+                .orElseGet(() -> new CachedUserProfile(null, "unknown", "unknown"));
+    }
+
+    /**
+     * 두개의 OpenChatDto 리스트를 합친다.
+     * @param openChatDtoListFromRedis List<OpenChatDto>
+     * @param openChatDtoList List<OpenChatDto>
+     * @return List<OpenChatDto>
+     */
+    private List<OpenChatDto> getMergeOepnChatDtoList(List<OpenChatDto> openChatDtoListFromRedis, List<OpenChatDto> openChatDtoList){
+        return Stream.concat(openChatDtoListFromRedis.stream(), openChatDtoList.stream())
+                .toList();
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
@@ -9,4 +9,6 @@ public interface OpenChatRedisService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
     public List<OpenChat> getOpenChatListByOpenChatRoomId(Long openChatRoomId);
     public List<OpenChat> getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit);
+    public void createOpenChat(OpenChat openChat);
+    public void updateLastOpenChat(OpenChat openChat);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisService.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface OpenChatRedisService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
     public List<OpenChat> getOpenChatListByOpenChatRoomId(Long openChatRoomId);
+    public List<OpenChat> getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
@@ -25,4 +25,12 @@ public class OpenChatRedisServiceImpl implements OpenChatRedisService {
     public List<OpenChat> getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit){
         return openChatRedisRepository.selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(openChatRoomId, offset, limit);
     };
+    @Override
+    public void createOpenChat(OpenChat openChat){
+        openChatRedisRepository.insertOpenChat(openChat);
+    };
+    @Override
+    public void updateLastOpenChat(OpenChat openChat){
+        openChatRedisRepository.updateLastOpenChat(openChat);
+    };
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatRedisServiceImpl.java
@@ -21,4 +21,8 @@ public class OpenChatRedisServiceImpl implements OpenChatRedisService {
     public List<OpenChat> getOpenChatListByOpenChatRoomId(Long openChatRoomId){
         return openChatRedisRepository.selectOpenChatListByChatRoomId(openChatRoomId);
     };
+    @Override
+    public List<OpenChat> getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit){
+        return openChatRedisRepository.selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(openChatRoomId, offset, limit);
+    };
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
@@ -2,7 +2,6 @@ package com.jongho.openChat.application.service;
 
 import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.domain.model.OpenChat;
-import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatService.java
@@ -1,6 +1,8 @@
 package com.jongho.openChat.application.service;
 
+import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.domain.model.OpenChat;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -8,4 +10,5 @@ import java.util.Optional;
 public interface OpenChatService {
     public Optional<OpenChat> getLastOpenChatByOpenChatRoomId(Long openChatRoomId);
     public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
+    public List<OpenChatDto> getOpenChatByOpenChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChat/application/service/OpenChatServiceImpl.java
@@ -1,10 +1,12 @@
 package com.jongho.openChat.application.service;
 
+import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.domain.model.OpenChat;
 import com.jongho.openChat.domain.repository.OpenChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,9 +18,12 @@ public class OpenChatServiceImpl implements OpenChatService{
         return openChatRepository.selectLastOpenChatByChatRoomId(openChatRoomId);
     };
     @Override
-    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit){
-        return openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
+    public int getUnReadOpenChatCountByOpenChatRoomIdAndLastExitTime(Long openChatRoomId, String lastCreatedTime, int limit){
+        return openChatRepository.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastCreatedTime, limit);
     }
-
+    @Override
+    public List<OpenChatDto> getOpenChatByOpenChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime, int limit){
+        return openChatRepository.selectOpenChatByChatRoomIdAndLastCreatedTime(openChatRoomId, lastCreatedTime, limit);
+    }
 
 }

--- a/api/src/main/java/com/jongho/openChat/common/enums/OpenChatTypeEnum.java
+++ b/api/src/main/java/com/jongho/openChat/common/enums/OpenChatTypeEnum.java
@@ -1,0 +1,18 @@
+package com.jongho.openChat.common.enums;
+
+public enum OpenChatTypeEnum {
+    TEXT(1),
+    IMAGE(2),
+    VIDEO(3),
+    NOTIFICATION(4);
+
+    private final int type;
+
+    OpenChatTypeEnum(int type) {
+        this.type = type;
+    }
+
+    public int getType() {
+        return type;
+    }
+}

--- a/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
+++ b/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
@@ -1,13 +1,20 @@
 package com.jongho.openChat.dao.mapper;
 
+import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.domain.model.OpenChat;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface OpenChatMapper {
     public OpenChat selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(
+            @Param("openChatRoomId") Long openChatRoomId,
+            @Param("lastExitTime") String lastExitTime,
+            @Param("limit") int limit);
+    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(
             @Param("openChatRoomId") Long openChatRoomId,
             @Param("lastExitTime") String lastExitTime,
             @Param("limit") int limit);

--- a/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
+++ b/api/src/main/java/com/jongho/openChat/dao/mapper/OpenChatMapper.java
@@ -14,8 +14,8 @@ public interface OpenChatMapper {
             @Param("openChatRoomId") Long openChatRoomId,
             @Param("lastExitTime") String lastExitTime,
             @Param("limit") int limit);
-    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(
+    public List<OpenChatDto> selectOpenChatByChatRoomIdAndLastCreatedTime(
             @Param("openChatRoomId") Long openChatRoomId,
-            @Param("lastExitTime") String lastExitTime,
+            @Param("lastCreatedTime") String lastCreatedTime,
             @Param("limit") int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
@@ -27,4 +27,13 @@ public class OpenChatRedisRepositoryImpl implements OpenChatRedisRepository {
                 RedisKeyGeneration.getChatRoomMessageKey(openChatRoomId),
                 OpenChat.class);
     };
+
+    @Override
+    public List<OpenChat> selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit){
+        return baseRedisTemplate.getReverseRangeListData(
+                RedisKeyGeneration.getChatRoomMessageKey(openChatRoomId),
+                OpenChat.class,
+                offset,
+                limit);
+    };
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRedisRepositoryImpl.java
@@ -36,4 +36,16 @@ public class OpenChatRedisRepositoryImpl implements OpenChatRedisRepository {
                 offset,
                 limit);
     };
+    @Override
+    public void insertOpenChat(OpenChat openChat){
+        baseRedisTemplate.setListData(
+                RedisKeyGeneration.getChatRoomMessageKey(openChat.getOpenChatRoomId()),
+                openChat);
+    };
+    @Override
+    public void updateLastOpenChat(OpenChat openChat){
+        baseRedisTemplate.setData(
+                RedisKeyGeneration.getLastMessageKey(openChat.getOpenChatRoomId()),
+                openChat);
+    };
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.jongho.openChat.dao.repository;
 
+import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.dao.mapper.OpenChatMapper;
 import com.jongho.openChat.domain.model.OpenChat;
 import com.jongho.openChat.domain.repository.OpenChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,4 +23,9 @@ public class OpenChatRepositoryImpl implements OpenChatRepository {
     public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit) {
         return openChatMapper.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
     }
+    @Override
+    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit) {
+        return openChatMapper.selectOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
+    }
+
 }

--- a/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChat/dao/repository/OpenChatRepositoryImpl.java
@@ -24,8 +24,8 @@ public class OpenChatRepositoryImpl implements OpenChatRepository {
         return openChatMapper.selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
     }
     @Override
-    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit) {
-        return openChatMapper.selectOpenChatCountByChatRoomIdAndLastExitTime(openChatRoomId, lastExitTime, limit);
+    public List<OpenChatDto> selectOpenChatByChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime, int limit) {
+        return openChatMapper.selectOpenChatByChatRoomIdAndLastCreatedTime(openChatRoomId, lastCreatedTime, limit);
     }
 
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
@@ -9,4 +9,6 @@ public interface OpenChatRedisRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public List<OpenChat> selectOpenChatListByChatRoomId(Long openChatRoomId);
     public List<OpenChat> selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit);
+    public void insertOpenChat(OpenChat openChat);
+    public void updateLastOpenChat(OpenChat openChat);
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRedisRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface OpenChatRedisRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public List<OpenChat> selectOpenChatListByChatRoomId(Long openChatRoomId);
+    public List<OpenChat> selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(Long openChatRoomId, int offset, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface OpenChatRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
-    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
+    public List<OpenChatDto> selectOpenChatByChatRoomIdAndLastCreatedTime(Long openChatRoomId, String lastCreatedTime, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
+++ b/api/src/main/java/com/jongho/openChat/domain/repository/OpenChatRepository.java
@@ -1,5 +1,6 @@
 package com.jongho.openChat.domain.repository;
 
+import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.domain.model.OpenChat;
 
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface OpenChatRepository {
     public Optional<OpenChat> selectLastOpenChatByChatRoomId(Long openChatRoomId);
     public int selectUnReadOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
+    public List<OpenChatDto> selectOpenChatCountByChatRoomIdAndLastExitTime(Long openChatRoomId, String lastExitTime, int limit);
 }

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class WebSocketOpenChatHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        // redis에 subscribe하고, init 메세지(채팅리스트)를 보낸다. limit은 100이고 lastCreatedTime 기준으로 커서기반의 조회를 한다.
     }
 
     @Override

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -59,7 +59,7 @@ public class WebSocketOpenChatHandler extends TextWebSocketHandler {
             }
         } catch (Exception e) {
             log.error(e.getMessage());
-            handleWebSocketClose(session, e);
+            handleWebSocketClose(session, BaseMessageTypeEnum.ERROR, e.getMessage());
         }
     }
     private void handleWebSocketClose(WebSocketSession session, BaseMessageTypeEnum type, String message) {

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -1,20 +1,69 @@
 package com.jongho.openChat.handler;
 
+import com.jongho.common.database.redis.RedisService;
+import com.jongho.common.util.websocket.BaseWebSocketMessage;
+import com.jongho.openChat.application.dto.OpenChatDto;
+import com.jongho.openChat.application.facade.WebSocketOpenChatFacade;
+import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
+import java.util.List;
+
 @Component
+@Log4j2
 @RequiredArgsConstructor
 public class WebSocketOpenChatHandler extends TextWebSocketHandler {
-    @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        // redis에 subscribe하고, init 메세지(채팅리스트)를 보낸다. limit은 100이고 lastCreatedTime 기준으로 커서기반의 조회를 한다.
-    }
+    private final WebSocketOpenChatFacade webSocketOpenChatFacade;
+    private final OpenChatRoomRedisService openChatRoomRedisService;
+    private final RedisService redisService;
+    private final String OPEN_CHAT_ROOM_CHANNEL = "openChatRoom:";
 
+    /**
+     * 웹소켓 연결이 열리고 사용자가 채팅방에 입장할 때 호출
+     * @param session 웹소켓 세션
+     */
+    @Override
+    public void afterConnectionEstablished(@NotNull WebSocketSession session){
+        try  {
+            Long openChatRoomId = (Long) session.getAttributes().get("openChatRoomId");
+            Long userId = (Long) session.getAttributes().get("userId");
+            List<OpenChatDto> openChatDtoList = webSocketOpenChatFacade.getInitialOpenChatList(openChatRoomId);
+            initConnectionInfoAndSubscribe(session, openChatRoomId, userId);
+
+            session.sendMessage(
+                    new TextMessage(BaseWebSocketMessage.of(openChatDtoList)));
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            handleWebSocketClose(session);
+        }
+    }
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    }
+    private void handleWebSocketClose(WebSocketSession session) {
+        try {
+            session.close();
+        } catch (IOException e) {
+            log.error("session.close");
+        }
+    }
+
+    /**
+     * 채팅장 입장 시 초기화 작업 및 채팅방 구독
+     * @param session 웹소켓 세션
+     * @param openChatRoomId 채팅방 아이디
+     * @param userId 사용자 아이디
+     */
+    private void initConnectionInfoAndSubscribe(WebSocketSession session, Long openChatRoomId, Long userId) {
+        openChatRoomRedisService.updateInitUnreadChatCount(userId, openChatRoomId);
+        openChatRoomRedisService.updateActiveChatRoom(userId, openChatRoomId);
+        redisService.subscribe(OPEN_CHAT_ROOM_CHANNEL + openChatRoomId, session);
     }
 }

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -5,6 +5,7 @@ import com.jongho.common.util.websocket.BaseMessageTypeEnum;
 import com.jongho.common.util.websocket.BaseWebSocketMessage;
 import com.jongho.openChat.application.dto.OpenChatDto;
 import com.jongho.openChat.application.facade.ReadWebSocketOpenChatFacade;
+import com.jongho.openChat.application.facade.ReadWebSocketOpenChatFacadeImpl;
 import com.jongho.openChat.application.facade.SendWebSocketOpenChatFacade;
 import com.jongho.openChatRoom.application.service.OpenChatRoomRedisService;
 import lombok.RequiredArgsConstructor;
@@ -50,13 +51,11 @@ public class WebSocketOpenChatHandler extends TextWebSocketHandler {
     @Override
     public void handleTextMessage(@NotNull WebSocketSession session, @NotNull TextMessage message) {
         try {
-            Long openChatRoomId = (Long) session.getAttributes().get("openChatRoomId");
-            Long userId = (Long) session.getAttributes().get("userId");
             BaseWebSocketMessage<OpenChatDto> baseWebSocketMessage = redisService.convertStringMessageToBaseWebSocketMessage(message);
 
             switch (baseWebSocketMessage.getType().getValue()) {
                 case "SEND" -> createOpenChatAndSendMessage(baseWebSocketMessage.getData());
-
+                case "PAGINATION" -> readWebSocketOpenChatFacade.getOpenChatListByOpenChatRoomIdAndLastCreatedTime(baseWebSocketMessage.getData().getOpenChatRoomId(), baseWebSocketMessage.getData().getCreatedTime());
             }
         } catch (Exception e) {
             log.error(e.getMessage());

--- a/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
+++ b/api/src/main/java/com/jongho/openChat/handler/WebSocketOpenChatHandler.java
@@ -45,7 +45,7 @@ public class WebSocketOpenChatHandler extends TextWebSocketHandler {
                     new TextMessage(BaseWebSocketMessage.of(BaseMessageTypeEnum.PAGINATION ,openChatDtoList)));
         } catch (Exception e) {
             log.error(e.getMessage());
-            handleWebSocketClose(session);
+            handleWebSocketClose(session, BaseMessageTypeEnum.ERROR, e.getMessage());
         }
     }
     @Override
@@ -59,11 +59,12 @@ public class WebSocketOpenChatHandler extends TextWebSocketHandler {
             }
         } catch (Exception e) {
             log.error(e.getMessage());
-            handleWebSocketClose(session);
+            handleWebSocketClose(session, e);
         }
     }
-    private void handleWebSocketClose(WebSocketSession session) {
+    private void handleWebSocketClose(WebSocketSession session, BaseMessageTypeEnum type, String message) {
         try {
+            session.sendMessage(new TextMessage(BaseWebSocketMessage.of(type, message)));
             session.close();
         } catch (IOException e) {
             log.error("session.close");

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -18,6 +18,7 @@ public interface OpenChatRoomRedisService {
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, String activeFlag);
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
+    public void updateLastExitTime(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -19,4 +19,5 @@ public interface OpenChatRoomRedisService {
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
     public void updateActiveChatRoom(Long userId, Long openChatRoomId);
+    public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -18,6 +18,6 @@ public interface OpenChatRoomRedisService {
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag);
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisService.java
@@ -17,4 +17,6 @@ public interface OpenChatRoomRedisService {
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
+    public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.common.util.date.DateUtil;
 import com.jongho.openChat.domain.model.OpenChat;
 import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
@@ -55,11 +56,15 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
         openChatRoomRedisRepository.updateInitUnreadChatCount(userId, openChatRoomId);
     }
     @Override
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag){
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, String activeFlag){
         openChatRoomRedisRepository.updateActiveChatRoom(userId, openChatRoomId, activeFlag);
     }
     @Override
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){
         openChatRoomRedisRepository.incrementUnreadMessageCount(userId, openChatRoomId);
+    }
+    @Override
+    public void updateLastExitTime(Long userId, Long openChatRoomId){
+        openChatRoomRedisRepository.updateLastExitTime(userId, openChatRoomId, DateUtil.now());
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -50,4 +50,12 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId){
         return openChatRoomRedisRepository.getOpenChatRoom(openChatRoomId);
     };
+    @Override
+    public void updateInitUnreadChatCount(Long userId, Long openChatRoomId){
+        openChatRoomRedisRepository.updateInitUnreadChatCount(userId, openChatRoomId);
+    }
+    @Override
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId){
+        openChatRoomRedisRepository.updateActiveChatRoom(userId, openChatRoomId);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -58,4 +58,8 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
     public void updateActiveChatRoom(Long userId, Long openChatRoomId){
         openChatRoomRedisRepository.updateActiveChatRoom(userId, openChatRoomId);
     }
+    @Override
+    public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){
+        openChatRoomRedisRepository.incrementUnreadMessageCount(userId, openChatRoomId);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImpl.java
@@ -55,8 +55,8 @@ public class OpenChatRoomRedisServiceImpl implements OpenChatRoomRedisService{
         openChatRoomRedisRepository.updateInitUnreadChatCount(userId, openChatRoomId);
     }
     @Override
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId){
-        openChatRoomRedisRepository.updateActiveChatRoom(userId, openChatRoomId);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag){
+        openChatRoomRedisRepository.updateActiveChatRoom(userId, openChatRoomId, activeFlag);
     }
     @Override
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){

--- a/api/src/main/java/com/jongho/openChatRoom/common/enums/ActiveTypeEnum.java
+++ b/api/src/main/java/com/jongho/openChatRoom/common/enums/ActiveTypeEnum.java
@@ -1,0 +1,16 @@
+package com.jongho.openChatRoom.common.enums;
+
+public enum ActiveTypeEnum {
+    ACTIVE(1),
+    INACTIVE(0);
+
+    private final int type;
+
+    ActiveTypeEnum(int type) {
+        this.type = type;
+    }
+
+    public int getType() {
+        return type;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/common/enums/ConnectionInfoFieldEnum.java
+++ b/api/src/main/java/com/jongho/openChatRoom/common/enums/ConnectionInfoFieldEnum.java
@@ -1,0 +1,16 @@
+package com.jongho.openChatRoom.common.enums;
+
+public enum ConnectionInfoFieldEnum {
+    ACTIVE("active"),
+    UN_READ_MESSAGE_COUNT("unReadMessageCount"),
+    LAST_EXIT_TIME("lastExitTime");
+    private final String field;
+
+    ConnectionInfoFieldEnum(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -70,10 +70,9 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
         baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, initCount);
     }
     @Override
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId){
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag){
         String ACTIVE = "active";
-        String value = "1";
-        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, value);
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, activeFlag);
     }
     @Override
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -63,4 +63,16 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
         return Optional.ofNullable(
                 baseRedisTemplate.getData(RedisKeyGeneration.getChatRoomKey(openChatRoomId), CachedOpenChatRoom.class));
     }
+    @Override
+    public void updateInitUnreadChatCount(Long userId, Long openChatRoomId){
+        String UNREAD_CHAT_COUNT = "unReadMessageCount";
+        String initCount = "0";
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, initCount);
+    }
+    @Override
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId){
+        String ACTIVE = "active";
+        String value = "1";
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, value);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import static com.jongho.openChatRoom.common.enums.ConnectionInfoFieldEnum.*;
+
 @Repository
 @RequiredArgsConstructor
 public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisRepository {
@@ -71,18 +73,14 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
     }
     @Override
     public void updateActiveChatRoom(Long userId, Long openChatRoomId, String activeFlag){
-        String ACTIVE = "active";
-        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, activeFlag);
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE.getField(), activeFlag);
     }
     @Override
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){
-        String UNREAD_CHAT_COUNT = "unReadMessageCount";
-        int value = 1;
-        baseRedisTemplate.incrementHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, value);
+        baseRedisTemplate.incrementHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UN_READ_MESSAGE_COUNT.getField(), 1);
     }
     @Override
     public void updateLastExitTime(Long userId, Long openChatRoomId, String lastExitTime){
-        String LAST_EXIT_TIME = "lastExitTime";
-        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), LAST_EXIT_TIME, lastExitTime);
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), LAST_EXIT_TIME.getField(), lastExitTime);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -70,7 +70,7 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
         baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, initCount);
     }
     @Override
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag){
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, String activeFlag){
         String ACTIVE = "active";
         baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, activeFlag);
     }
@@ -79,5 +79,10 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
         String UNREAD_CHAT_COUNT = "unReadMessageCount";
         int value = 1;
         baseRedisTemplate.incrementHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, value);
+    }
+    @Override
+    public void updateLastExitTime(Long userId, Long openChatRoomId, String lastExitTime){
+        String LAST_EXIT_TIME = "lastExitTime";
+        baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), LAST_EXIT_TIME, lastExitTime);
     }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/openChatRoom/dao/repository/OpenChatRoomRedisRepositoryImpl.java
@@ -75,4 +75,10 @@ public class OpenChatRoomRedisRepositoryImpl implements OpenChatRoomRedisReposit
         String value = "1";
         baseRedisTemplate.setHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), ACTIVE, value);
     }
+    @Override
+    public void incrementUnreadMessageCount(Long userId, Long openChatRoomId){
+        String UNREAD_CHAT_COUNT = "unReadMessageCount";
+        int value = 1;
+        baseRedisTemplate.incrementHashDataColumn(RedisKeyGeneration.getChatRoomConnectionInfoKey(userId, openChatRoomId), UNREAD_CHAT_COUNT, value);
+    }
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -18,6 +18,6 @@ public interface OpenChatRoomRedisRepository {
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag);
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -17,4 +17,6 @@ public interface OpenChatRoomRedisRepository {
     public List<Long> getOpenChatRoomUserList(Long openChatRoomId);
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
+    public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -19,4 +19,5 @@ public interface OpenChatRoomRedisRepository {
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
     public void updateActiveChatRoom(Long userId, Long openChatRoomId);
+    public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
+++ b/api/src/main/java/com/jongho/openChatRoom/domain/repository/OpenChatRoomRedisRepository.java
@@ -18,6 +18,7 @@ public interface OpenChatRoomRedisRepository {
     public CachedOpenChatRoomConnectionInfo getRedisOpenChatRoomConnectionInfo(Long userId, Long openChatRoomId);
     public Optional<CachedOpenChatRoom> getOpenChatRoom(Long openChatRoomId);
     public void updateInitUnreadChatCount(Long userId, Long openChatRoomId);
-    public void updateActiveChatRoom(Long userId, Long openChatRoomId, int activeFlag);
+    public void updateActiveChatRoom(Long userId, Long openChatRoomId, String activeFlag);
     public void incrementUnreadMessageCount(Long userId, Long openChatRoomId);
+    public void updateLastExitTime(Long userId, Long openChatRoomId, String lastExitTime);
 }

--- a/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
+++ b/api/src/main/java/com/jongho/openChatRoom/handler/WebSocketOpenChatRoomHandler.java
@@ -1,6 +1,7 @@
 package com.jongho.openChatRoom.handler;
 
 import com.jongho.common.database.redis.RedisService;
+import com.jongho.common.util.websocket.BaseMessageTypeEnum;
 import com.jongho.common.util.websocket.BaseWebSocketMessage;
 import com.jongho.openChatRoom.application.dto.response.OpenChatRoomDto;
 import com.jongho.openChatRoom.application.facade.WebSocketOpenChatRoomFacade;
@@ -29,7 +30,7 @@ public class WebSocketOpenChatRoomHandler extends TextWebSocketHandler {
             redisService.subscribe(getChannelList(openChatRoomDto), session);
 
             session.sendMessage(
-                    new TextMessage(BaseWebSocketMessage.of(openChatRoomDto)));
+                    new TextMessage(BaseWebSocketMessage.of(BaseMessageTypeEnum.PAGINATION, openChatRoomDto)));
         } catch (Exception e) {
             log.error(e.getMessage());
             handleWebSocketClose(session);

--- a/api/src/main/java/com/jongho/user/application/service/UserRedisService.java
+++ b/api/src/main/java/com/jongho/user/application/service/UserRedisService.java
@@ -1,8 +1,8 @@
-package com.jongho.user.domain.repository;
+package com.jongho.user.application.service;
 
 import com.jongho.user.domain.model.redis.CachedUserProfile;
 
-public interface UserRedisRepository {
-    public CachedUserProfile selectUserProfileByUserId(Long userId);
+public interface UserRedisService {
+    public CachedUserProfile getUserProfileByUserId(Long userId);
     public void createUserProfileByUserId(Long userId, String nickname, String profileImage);
 }

--- a/api/src/main/java/com/jongho/user/application/service/UserRedisServiceImpl.java
+++ b/api/src/main/java/com/jongho/user/application/service/UserRedisServiceImpl.java
@@ -1,0 +1,22 @@
+package com.jongho.user.application.service;
+
+import com.jongho.user.domain.model.redis.CachedUserProfile;
+import com.jongho.user.domain.repository.UserRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRedisServiceImpl implements UserRedisService {
+    private final UserRedisRepository userRedisRepository;
+
+    @Override
+    public CachedUserProfile getUserProfileByUserId(Long userId){
+        return userRedisRepository.selectUserProfileByUserId(userId);
+    }
+
+    @Override
+    public void createUserProfileByUserId(Long userId, String nickname, String profileImage){
+        userRedisRepository.createUserProfileByUserId(userId, nickname, profileImage);
+    }
+}

--- a/api/src/main/java/com/jongho/user/dao/repository/UserRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/user/dao/repository/UserRedisRepositoryImpl.java
@@ -13,6 +13,10 @@ public class UserRedisRepositoryImpl implements UserRedisRepository {
     private final BaseRedisTemplate baseRedisTemplate;
     @Override
     public CachedUserProfile selectUserProfileByUserId(Long userId) {
-        return baseRedisTemplate.getHashData(RedisKeyGeneration.getUserProfileKey(userId), CachedUserProfile.class);
+        return baseRedisTemplate.getData(RedisKeyGeneration.getUserProfileKey(userId), CachedUserProfile.class);
+    }
+    @Override
+    public void createUserProfileByUserId(Long userId, String nickname, String profileImage) {
+        baseRedisTemplate.setData(RedisKeyGeneration.getUserProfileKey(userId), new CachedUserProfile(userId, nickname, profileImage));
     }
 }

--- a/api/src/main/java/com/jongho/user/dao/repository/UserRedisRepositoryImpl.java
+++ b/api/src/main/java/com/jongho/user/dao/repository/UserRedisRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.jongho.user.dao.repository;
+
+import com.jongho.common.util.redis.BaseRedisTemplate;
+import com.jongho.common.util.redis.RedisKeyGeneration;
+import com.jongho.user.domain.model.redis.CachedUserProfile;
+import com.jongho.user.domain.repository.UserRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRedisRepositoryImpl implements UserRedisRepository {
+    private final BaseRedisTemplate baseRedisTemplate;
+    @Override
+    public CachedUserProfile selectUserProfileByUserId(Long userId) {
+        return baseRedisTemplate.getHashData(RedisKeyGeneration.getUserProfileKey(userId), CachedUserProfile.class);
+    }
+}

--- a/api/src/main/java/com/jongho/user/domain/model/redis/CachedUserProfile.java
+++ b/api/src/main/java/com/jongho/user/domain/model/redis/CachedUserProfile.java
@@ -1,0 +1,25 @@
+package com.jongho.user.domain.model.redis;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public
+class CachedUserProfile{
+    private final Long id;
+    private final String nickname;
+    private final String profileImage;
+
+    @JsonCreator
+    public CachedUserProfile(
+            @JsonProperty("id") Long id,
+            @JsonProperty("nickname") String name,
+            @JsonProperty("profileImage") String profileImage) {
+        this.id = id;
+        this.nickname = name;
+        this.profileImage = profileImage;
+    }
+}

--- a/api/src/main/java/com/jongho/user/domain/model/redis/CachedUserProfile.java
+++ b/api/src/main/java/com/jongho/user/domain/model/redis/CachedUserProfile.java
@@ -16,10 +16,10 @@ class CachedUserProfile{
     @JsonCreator
     public CachedUserProfile(
             @JsonProperty("id") Long id,
-            @JsonProperty("nickname") String name,
+            @JsonProperty("nickname") String nickname,
             @JsonProperty("profileImage") String profileImage) {
         this.id = id;
-        this.nickname = name;
+        this.nickname = nickname;
         this.profileImage = profileImage;
     }
 }

--- a/api/src/main/java/com/jongho/user/domain/repository/UserRedisRepository.java
+++ b/api/src/main/java/com/jongho/user/domain/repository/UserRedisRepository.java
@@ -1,0 +1,7 @@
+package com.jongho.user.domain.repository;
+
+import com.jongho.user.domain.model.redis.CachedUserProfile;
+
+public interface UserRedisRepository {
+    public CachedUserProfile selectUserProfileByUserId(Long userId);
+}

--- a/api/src/main/resources/mapper/openChatMapper.xml
+++ b/api/src/main/resources/mapper/openChatMapper.xml
@@ -25,22 +25,7 @@
         AND is_deleted = 0
         LIMIT #{limit}
     </select>
-    <resultMap id="openChatDtoResultMap" type="com.jongho.openChat.application.dto.OpenChatDto">
-        <id property="id" column="id"/>
-        <result property="openChatRoomId" column="openChatRoomId"/>
-        <result property="message" column="message"/>
-        <result property="type" column="type"/>
-        <result property="isDeleted" column="isDeleted"/>
-        <result property="deletedTime" column="deletedTime"/>
-        <result property="createdTime" column="createdTime"/>
-        <association property="senderInfo" resultMap="senderInfoResultMap"/>
-    </resultMap>
-    <resultMap id="senderInfoResultMap" type="com.jongho.user.domain.model.redis.CachedUserProfile">
-        <result property="id" column="id"/>
-        <result property="nickname" column="nickname"/>
-        <result property="profileImage" column="profileImage"/>
-    </resultMap>
-    <select id="selectOpenChatCountByChatRoomIdAndLastExitTime" resultMap="openChatDtoResultMap">
+    <select id="selectOpenChatByChatRoomIdAndLastCreatedTime" resultType="com.jongho.openChat.application.dto.OpenChatDto">
         SELECT
             open_chats.id,
             open_chats.open_chat_room_id,
@@ -48,16 +33,16 @@
             open_chats.type,
             open_chats.is_deleted,
             open_chats.deleted_time,
-            open_chats.created_time
-            users.id as "senderInfo.id",
-            users.nickname as "senderInfo.nickname",
-            users.profile_image as "senderInfo.profileImage"
+            open_chats.created_time,
+            u.id as sender_id,
+            u.nickname as sender_nickname,
+            u.profile_image as sender_profileImage
         FROM open_chats
-        INNER JOIN users
-            ON open_chats.sender_id = users.id
-        WHERE open_chat_room_id = #{openChatRoomId}
+        INNER JOIN users as u
+            ON u.id = open_chats.sender_id
+        WHERE open_chats.open_chat_room_id = #{openChatRoomId}
         AND open_chats.created_time &lt; #{lastCreatedTime}
-        ORDER BY open_chats.createdTime DESC
+        ORDER BY open_chats.created_time DESC
         LIMIT #{limit}
     </select>
 </mapper>

--- a/api/src/main/resources/mapper/openChatMapper.xml
+++ b/api/src/main/resources/mapper/openChatMapper.xml
@@ -25,4 +25,39 @@
         AND is_deleted = 0
         LIMIT #{limit}
     </select>
+    <resultMap id="openChatDtoResultMap" type="com.jongho.openChat.application.dto.OpenChatDto">
+        <id property="id" column="id"/>
+        <result property="openChatRoomId" column="openChatRoomId"/>
+        <result property="message" column="message"/>
+        <result property="type" column="type"/>
+        <result property="isDeleted" column="isDeleted"/>
+        <result property="deletedTime" column="deletedTime"/>
+        <result property="createdTime" column="createdTime"/>
+        <association property="senderInfo" resultMap="senderInfoResultMap"/>
+    </resultMap>
+    <resultMap id="senderInfoResultMap" type="com.jongho.user.domain.model.redis.CachedUserProfile">
+        <result property="id" column="id"/>
+        <result property="nickname" column="nickname"/>
+        <result property="profileImage" column="profileImage"/>
+    </resultMap>
+    <select id="selectOpenChatCountByChatRoomIdAndLastExitTime" resultMap="openChatDtoResultMap">
+        SELECT
+            open_chats.id,
+            open_chats.open_chat_room_id,
+            open_chats.message,
+            open_chats.type,
+            open_chats.is_deleted,
+            open_chats.deleted_time,
+            open_chats.created_time
+            users.id as "senderInfo.id",
+            users.nickname as "senderInfo.nickname",
+            users.profile_image as "senderInfo.profileImage"
+        FROM open_chats
+        INNER JOIN users
+            ON open_chats.sender_id = users.id
+        WHERE open_chat_room_id = #{openChatRoomId}
+        AND open_chats.created_time &lt; #{lastCreatedTime}
+        ORDER BY open_chats.createdTime DESC
+        LIMIT #{limit}
+    </select>
 </mapper>

--- a/api/src/main/resources/mapper/userMapper.xml
+++ b/api/src/main/resources/mapper/userMapper.xml
@@ -25,7 +25,7 @@
 
     <select id="findOneById" parameterType="Long" resultType="com.jongho.user.domain.model.User">
         SELECT
-        users.id, users.nickname, users.password, users.username, users.profile_image, users.phone_number
+        users.id, users.nickname, users.password, users.username, users.phone_number, users.profile_image
         FROM users
         WHERE users.id = #{id}
         AND users.deleted_time is null

--- a/api/src/test/java/com/jongho/openChat/application/service/OpenChatRedisServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChat/application/service/OpenChatRedisServiceImplTest.java
@@ -77,5 +77,82 @@ public class OpenChatRedisServiceImplTest {
                 assertEquals(1, result.size());
             }
         }
+        @Nested
+        @DisplayName("getOpenChatListByOpenChatRoomIdAndOffsetAndLimit 메소드는")
+        class Describe_getOpenChatListByOpenChatRoomIdAndOffsetAndLimit {
+            @Test
+            @DisplayName("openChatRedisRepository.selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit 메소드를 호출하고 받은 반환값을 반환한다.")
+            void openChatRedisRepository_selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit_메소드를_호출하고_받은_반환값을_반환한다() {
+                // given
+                List<OpenChat> openChatList = List.of(new OpenChat(
+                        1L,
+                        1L,
+                        1L,
+                        "test",
+                        1,
+                        0,
+                        null,
+                        "2024-01-29 00:00:00"
+                ));
+                when(openChatRedisRepository.selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(1L, 0, 1)).thenReturn(openChatList);
+
+                // when
+                List<OpenChat> result = openChatRedisService.getOpenChatListByOpenChatRoomIdAndOffsetAndLimit(1L, 0, 1);
+
+                // then
+                verify(openChatRedisRepository).selectOpenChatListByOpenChatRoomIdAndOffsetAndLimit(1L, 0, 1);
+                assertEquals(1, result.size());
+            }
+        }
+        @Nested
+        @DisplayName("createOpenChat 메소드는")
+        class Describe_createOpenChat {
+            @Test
+            @DisplayName("openChatRedisRepository.insertOpenChat 메소드를 호출해서 채팅을 생성한다.")
+            void openChatRedisRepository_insertOpenChat_메소드를_호출해서_채팅을_생성한다() {
+                // given
+                OpenChat openChat = new OpenChat(
+                        1L,
+                        1L,
+                        1L,
+                        "test",
+                        1,
+                        0,
+                        null,
+                        "2024-01-29 00:00:00"
+                );
+
+                // when
+                openChatRedisService.createOpenChat(openChat);
+
+                // then
+                verify(openChatRedisRepository).insertOpenChat(openChat);
+            }
+        }
+        @Nested
+        @DisplayName("updateLastOpenChat 메소드는")
+        class Describe_updateLastOpenChat {
+            @Test
+            @DisplayName("openChatRedisRepository.updateLastOpenChat 메소드를 호출해서 마지막 채팅을 업데이트한다.")
+            void openChatRedisRepository_updateLastOpenChat_메소드를_호출해서_마지막_채팅을_업데이트한다() {
+                // given
+                OpenChat openChat = new OpenChat(
+                        1L,
+                        1L,
+                        1L,
+                        "test",
+                        1,
+                        0,
+                        null,
+                        "2024-01-29 00:00:00"
+                );
+
+                // when
+                openChatRedisService.updateLastOpenChat(openChat);
+
+                // then
+                verify(openChatRedisRepository).updateLastOpenChat(openChat);
+            }
+        }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/application/service/OpenChatRoomRedisServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.jongho.openChatRoom.application.service;
 
+import com.jongho.common.util.date.DateUtil;
 import com.jongho.openChat.domain.model.OpenChat;
 import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoom;
 import com.jongho.openChatRoom.domain.model.redis.CachedOpenChatRoomConnectionInfo;
@@ -16,8 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OpenChatRoomRedisServiceImpl 클래스")
@@ -177,6 +177,73 @@ public class OpenChatRoomRedisServiceImplTest {
             // then
             verify(openChatRoomRedisRepository).getOpenChatRoom(1L);
             assertEquals(redisOpenChatRoom, result);
+        }
+    }
+    @Nested
+    @DisplayName("updateInitUnreadChatCount 메서드는")
+    class Describe_updateInitUnreadChatCount{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.updateInitUnreadChatCount 메서드를 호출해서 안읽은 메세지를 초기화시킨다.")
+        void openChatRoomRedisRepositoryd_updateInitUnreadChatCount_메서드를_호출해서_안읽은_메세지를_초기화시킨다(){
+            // given
+            doNothing().when(openChatRoomRedisRepository).updateInitUnreadChatCount(1L, 1L);
+
+            // when
+            openChatRoomRedisService.updateInitUnreadChatCount(1L, 1L);
+
+            // then
+            verify(openChatRoomRedisRepository).updateInitUnreadChatCount(1L, 1L);
+        }
+    }
+    @Nested
+    @DisplayName("updateActiveChatRoom 메서드는")
+    class Describe_updateActiveChatRoom{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.updateActiveChatRoom 메서드를 호출해서 채팅방의 활성화 상태를 변경한다.")
+        void openChatRoomRedisRepositoryd_updateActiveChatRoom_메서드를_호출해서_채팅방의_활성화_상태를_변경한다(){
+            // given
+            String ACTIVE = "1";
+            doNothing().when(openChatRoomRedisRepository).updateActiveChatRoom(1L, 1L, ACTIVE);
+
+            // when
+            openChatRoomRedisService.updateActiveChatRoom(1L, 1L, ACTIVE);
+
+            // then
+            verify(openChatRoomRedisRepository).updateActiveChatRoom(1L, 1L, ACTIVE);
+        }
+    }
+    @Nested
+    @DisplayName("incrementUnreadMessageCount 메서드는")
+    class Describe_incrementUnreadMessageCount{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.incrementUnreadMessageCount 메서드를 호출해서 안읽은 메세지 수를 증가시킨다.")
+        void openChatRoomRedisRepositoryd_incrementUnreadMessageCount_메서드를_호출해서_안읽은_메세지_수를_증가시킨다(){
+            // given
+            doNothing().when(openChatRoomRedisRepository).incrementUnreadMessageCount(1L, 1L);
+
+            // when
+            openChatRoomRedisService.incrementUnreadMessageCount(1L, 1L);
+
+            // then
+            verify(openChatRoomRedisRepository).incrementUnreadMessageCount(1L, 1L);
+        }
+    }
+    @Nested
+    @DisplayName("updateLastExitTime 메서드는")
+    class Describe_updateLastExitTime{
+        @Test
+        @DisplayName("openChatRoomRedisRepository.updateLastExitTime 메서드를 호출해서 마지막 채팅방 나간 시간을 업데이트한다.")
+        void openChatRoomRedisRepositoryd_updateLastExitTime_메서드를_호출해서_마지막_채팅방_나간_시간을_업데이트한다(){
+            // given
+            String LAST_EXIT_TIME = DateUtil.now();
+
+            doNothing().when(openChatRoomRedisRepository).updateLastExitTime(1L, 1L, LAST_EXIT_TIME);
+
+            // when
+            openChatRoomRedisService.updateLastExitTime(1L, 1L);
+
+            // then
+            verify(openChatRoomRedisRepository).updateLastExitTime(1L, 1L, LAST_EXIT_TIME);
         }
     }
 }

--- a/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
+++ b/api/src/test/java/com/jongho/openChatRoom/presentation/OpenChatRoomControllerTest.java
@@ -20,6 +20,8 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Map;
+
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -65,7 +67,12 @@ public class OpenChatRoomControllerTest {
                     200,
                     "비밀번호"));
             Gson gson = new Gson();
-            String openChatRoomCreateDtoJson = gson.toJson(openChatRoomCreateDto);
+            String openChatRoomCreateDtoJson = gson.toJson(
+                    Map.of("title", "타이틀",
+                    "notice", "공지사항",
+                    "category_id", 1L,
+                    "maximum_capacity", 200,
+                    "password", "비밀번호"));
 
             // when
             mockMvc.perform(post("/api/v1/open-chat-rooms")


### PR DESCRIPTION
## 기능 정의
웹소켓을 이용한 채팅방 입장시 채팅방 내역을 받으며
채팅방에 입장한 사람과 채팅을 주고받을수 있는 기능

## 주요 변경 및 추가 사항
1. 소켓 커넥션시 커서기반의 페이지네이션으로 채팅내역을 받으며 
유저의 상태를 활성화 시키고 안읽은 메세지 카운트를 초기화 시키는 로직을 작성

2. 메세지 이벤트 발생시 메세지 타입에 따라 SEND의 경우 채팅을 저장하고 상대방에게 보낼수 있는 로직을 작성
PAGINATION의 경우 마지막 읽은 채팅을 기준으로 뒤의 채팅내역을 받을수 있는 로직을 작성

3. 소켓 커넥션 닫힘 이벤트 발생시 유저의 활성상태를 비활성으로 바꾸며 마지막으로 나간 날짜를 업데이트 시켜주고
커넥션을 close하는 로직을 작성

## 테스트
채팅 관련 application 레이어단 로직의 테스트코드를 작성

## 블로커
mapper.xml에서 중첩객체에 대한 resultMap의 사용이 원활하지 않아 하루정도 시도끝에 
어플리케이션단의 코드를 변경하는걸로 방향을 바꿔서 진행하였습니다.

## 미흡한점
아직은 xml에 sql문을 작성하는것이 문법적으로 익숙하지 않아서 프로그래밍보다는
문법에서 시간을 많이 잡아먹은것 같습니다.
